### PR TITLE
Extract and return PCR digest for Quote on TPM1.2

### DIFF
--- a/attest/tpm_linux.go
+++ b/attest/tpm_linux.go
@@ -341,14 +341,21 @@ func (k *Key) ActivateCredential(t *TPM, in EncryptedCredential) ([]byte, error)
 }
 
 func (k *Key) quote12(ctx *tspi.Context, nonce []byte) (*Quote, error) {
-	quote, rawSig, err := attestation.GetQuote(ctx, k.KeyBlob, nonce)
+	quoteInfo, rawSig, err := attestation.GetQuote(ctx, k.KeyBlob, nonce)
 	if err != nil {
 		return nil, fmt.Errorf("GetQuote() failed: %v", err)
+	}
+	// go-tspi returns TPM_QUOTE_INFO. We only want the digest of the PCRs
+	var version [4]byte
+	var quot [4]byte
+	var digest [20]byte
+	if _, err := tpmutil.Unpack(quoteInfo, &version, &quot, &digest); err != nil {
+		return nil, fmt.Errorf("unable to parse PCR digest from TPM_QUOTE_INFO: %v", err)
 	}
 
 	return &Quote{
 		Version:   TPMVersion12,
-		Quote:     quote,
+		Quote:     digest[:],
 		Signature: rawSig,
 	}, nil
 }

--- a/attest/tpm_windows.go
+++ b/attest/tpm_windows.go
@@ -19,6 +19,7 @@ package attest
 import (
 	"crypto"
 	"crypto/rand"
+	"crypto/sha1"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
@@ -271,10 +272,11 @@ func (k *Key) quote12(tpm io.ReadWriter, nonce []byte) (*Quote, error) {
 		selectedPCRs[pcr] = pcr
 	}
 
-	sig, quote, err := tpm1.Quote(tpm, k.hnd12, nonce, selectedPCRs[:], wellKnownAuth[:])
+	sig, pcrc, err := tpm1.Quote(tpm, k.hnd12, nonce, selectedPCRs[:], wellKnownAuth[:])
 	if err != nil {
 		return nil, fmt.Errorf("Quote() failed: %v", err)
 	}
+	quote := sha1.Sum(pcrc)
 	return &Quote{
 		Quote:     quote,
 		Signature: sig,


### PR DESCRIPTION
go-tspi and go-tpm return different values for "quote".
In both cases we want the PCR digest so we extract it from the data returned.