### PR TITLE
Attempt fix for EKCert parsing errors when falling back to NVRAM

### DIFF
--- a/attest/pcp_windows.go
+++ b/attest/pcp_windows.go
@@ -404,7 +404,7 @@ func (h *winPCP) EKCerts() ([]*x509.Certificate, error) {
 
 	var out []*x509.Certificate
 	for _, der := range c {
-		cert, err := x509.ParseCertificate(der)
+		cert, err := parseCert(der)
 		if err != nil && x509.IsFatal(err) {
 			return nil, err
 		}

--- a/attest/pcp_windows.go
+++ b/attest/pcp_windows.go
@@ -405,7 +405,7 @@ func (h *winPCP) EKCerts() ([]*x509.Certificate, error) {
 	var out []*x509.Certificate
 	for _, der := range c {
 		cert, err := parseCert(der)
-		if err != nil && x509.IsFatal(err) {
+		if err != nil {
 			return nil, err
 		}
 		out = append(out, cert)

--- a/attest/tpm.go
+++ b/attest/tpm.go
@@ -15,8 +15,10 @@
 package attest
 
 import (
+	"bytes"
 	"crypto"
 	"encoding/asn1"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"math/big"
@@ -128,6 +130,14 @@ func readTPM2VendorAttributes(tpm io.ReadWriter) (TCGVendorID, string, error) {
 }
 
 func parseCert(ekCert []byte) (*x509.Certificate, error) {
+	// TCG PC Specific Implementation section 7.3.2 specifies
+	// a prefix when storing a certificate in NVRAM. We look
+	// for and unwrap the certificate if its present.
+	if len(ekCert) > 5 && bytes.Equal(ekCert[:3], []byte{0x10, 0x01, 0x00}) {
+		certLen := binary.BigEndian.Uint16(ekCert[3:5])
+		ekCert = ekCert[5 : 5+certLen]
+	}
+
 	// If the cert parses fine without any changes, we are G2G.
 	if c, err := x509.ParseCertificate(ekCert); err == nil {
 		return c, nil


### PR DESCRIPTION
```
FATAL: 2019/06/10 16:19:49.223469 <REDACTED> EKs() failed: could not read EKCerts: asn1: structure 
error: tags don't match (16 vs {class:3 tag:0 length:7 isCompound:false}) {optional:false explicit:false application:false private:false defaultValue:&lt;nil&gt; tag:&lt;nil&gt; stringType:0 timeType:0 set:false omitEmpty:false lax:true name:}
certificate @2
```