### PR TITLE
Add a Public() method to the AIK that returns a public key

### DIFF
--- a/attest/attest.go
+++ b/attest/attest.go
@@ -100,6 +100,7 @@ type aik interface {
 	ActivateCredential(tpm *TPM, in EncryptedCredential) ([]byte, error)
 	Quote(t *TPM, nonce []byte, alg HashAlg) (*Quote, error)
 	Parameters() AIKParameters
+	Public() crypto.PublicKey
 }
 
 // AIK represents a key which can be used for attestation.
@@ -135,6 +136,11 @@ func (k *AIK) Quote(tpm *TPM, nonce []byte, alg HashAlg) (*Quote, error) {
 // a credential activation challenge.
 func (k *AIK) Parameters() AIKParameters {
 	return k.aik.Parameters()
+}
+
+// Public returns the public part of the AIK.
+func (k *AIK) Public() crypto.PublicKey {
+	return k.aik.Public()
 }
 
 // MintOptions encapsulates parameters for minting keys. This type is defined

--- a/attest/tpm_windows.go
+++ b/attest/tpm_windows.go
@@ -311,26 +311,17 @@ func (t *TPM) MintAIK(opts *MintOptions) (*AIK, error) {
 
 	switch t.version {
 	case TPMVersion12:
-		return &AIK{
-			aik: &key12{
-				hnd:        kh,
-				pcpKeyName: name,
-				public:     props.RawPublic,
-			},
-		}, nil
-
+		aik, err := newKey12(kh, name, props.RawPublic)
+		if err != nil {
+			return nil, fmt.Errorf("unpacking aik: %v", err)
+		}
+		return &AIK{aik: aik}, nil
 	case TPMVersion20:
-		return &AIK{
-			aik: &key20{
-				hnd:               kh,
-				pcpKeyName:        name,
-				public:            props.RawPublic,
-				createData:        props.RawCreationData,
-				createAttestation: props.RawAttest,
-				createSignature:   props.RawSignature,
-			},
-		}, nil
-
+		aik, err := newKey20(kh, name, props.RawPublic, props.RawCreationData, props.RawAttest, props.RawSignature)
+		if err != nil {
+			return nil, fmt.Errorf("unpacking aik: %v", err)
+		}
+		return &AIK{aik: aik}, nil
 	default:
 		return nil, fmt.Errorf("cannot handle TPM version: %v", t.version)
 	}
@@ -352,25 +343,17 @@ func (t *TPM) loadAIK(opaqueBlob []byte) (*AIK, error) {
 
 	switch t.version {
 	case TPMVersion12:
-		return &AIK{
-			aik: &key12{
-				hnd:        hnd,
-				pcpKeyName: sKey.Name,
-				public:     sKey.Public,
-			},
-		}, nil
+		aik, err := newKey12(hnd, sKey.Name, sKey.Public)
+		if err != nil {
+			return nil, fmt.Errorf("unpacking aik: %v", err)
+		}
+		return &AIK{aik: aik}, nil
 	case TPMVersion20:
-		return &AIK{
-			aik: &key20{
-				hnd:               hnd,
-				pcpKeyName:        sKey.Name,
-				public:            sKey.Public,
-				createData:        sKey.CreateData,
-				createAttestation: sKey.CreateAttestation,
-				createSignature:   sKey.CreateSignature,
-			},
-		}, nil
-
+		aik, err := newKey20(hnd, sKey.Name, sKey.Public, sKey.CreateData, sKey.CreateAttestation, sKey.CreateSignature)
+		if err != nil {
+			return nil, fmt.Errorf("unpacking aik: %v", err)
+		}
+		return &AIK{aik: aik}, nil
 	default:
 		return nil, fmt.Errorf("cannot handle TPM version: %v", t.version)
 	}


### PR DESCRIPTION
We plan to identify AIKs based on their public key. The raw blob should
be available via the AttestationParameters, but we hope that users will
only use that struct for generating challenges.

Because this parses the public key on AIK creation and loading, this PR
should have existing coverage.