### PR TITLE
attest: remove unused KeyPurpose exported type

### DIFF
--- a/attest/attest.go
+++ b/attest/attest.go
@@ -83,17 +83,6 @@ const (
 	keyEncodingParameterized
 )
 
-// KeyPurpose indicates the intended use of the key. It is implied that
-// the key was created with usage restrictions to constrain its use
-// to the given purpose.
-type KeyPurpose uint8
-
-// Key purposes.
-const (
-	AttestationKey KeyPurpose = iota
-	StorageKey
-)
-
 type aik interface {
 	Close(*TPM) error
 	Marshal() ([]byte, error)


### PR DESCRIPTION
Was going through the godoc and it's not clear that this is ever used.
To clean up the API, remove KeyPurpose for now. This could probably be
an internal validation anyway, right?

@twitchy-jsonp please wait to get back from OOO before reviewing. Not going to merge anything without your review.