### PR TITLE
attest: move public key parsing server side

### DIFF
--- a/attest/attest_simulated_tpm20_test.go
+++ b/attest/attest_simulated_tpm20_test.go
@@ -153,6 +153,21 @@ func TestSimTPM20ActivateCredential(t *testing.T) {
 	}
 }
 
+func TestParseAIKPublic20(t *testing.T) {
+	sim, tpm := setupSimulatedTPM(t)
+	defer sim.Close()
+
+	aik, err := tpm.MintAIK(nil)
+	if err != nil {
+		t.Fatalf("MintAIK() failed: %v", err)
+	}
+	defer aik.Close(tpm)
+	params := aik.AttestationParameters()
+	if _, err := ParseAIKPublic(TPMVersion20, params.Public); err != nil {
+		t.Errorf("parsing AIK public blob: %v", err)
+	}
+}
+
 func TestSimTPM20Quote(t *testing.T) {
 	sim, tpm := setupSimulatedTPM(t)
 	defer sim.Close()

--- a/attest/key_windows.go
+++ b/attest/key_windows.go
@@ -17,7 +17,6 @@
 package attest
 
 import (
-	"crypto"
 	"fmt"
 
 	tpm1 "github.com/google/go-tpm/tpm"
@@ -29,25 +28,14 @@ type key12 struct {
 	hnd        uintptr
 	pcpKeyName string
 	public     []byte
-
-	publicKey crypto.PublicKey
 }
 
-func newKey12(hnd uintptr, pcpKeyName string, public []byte) (aik, error) {
-	rsaPub, err := tpm1.UnmarshalPubRSAPublicKey(public)
-	if err != nil {
-		return nil, fmt.Errorf("parsing public key: %v", err)
-	}
+func newKey12(hnd uintptr, pcpKeyName string, public []byte) aik {
 	return &key12{
 		hnd:        hnd,
 		pcpKeyName: pcpKeyName,
 		public:     public,
-		publicKey:  rsaPub,
-	}, nil
-}
-
-func (k *key12) Public() crypto.PublicKey {
-	return k.publicKey
+	}
 }
 
 // Marshal represents the key in a persistent format which may be
@@ -127,19 +115,9 @@ type key20 struct {
 	createData        []byte
 	createAttestation []byte
 	createSignature   []byte
-
-	publicKey crypto.PublicKey
 }
 
-func newKey20(hnd uintptr, pcpKeyName string, public, createData, createAttest, createSig []byte) (aik, error) {
-	pub, err := tpm2.DecodePublic(public)
-	if err != nil {
-		return nil, fmt.Errorf("parsing TPM public key structure: %v", err)
-	}
-	pubKey, err := pub.Key()
-	if err != nil {
-		return nil, fmt.Errorf("parsing public key: %v", err)
-	}
+func newKey20(hnd uintptr, pcpKeyName string, public, createData, createAttest, createSig []byte) aik {
 	return &key20{
 		hnd:               hnd,
 		pcpKeyName:        pcpKeyName,
@@ -147,12 +125,7 @@ func newKey20(hnd uintptr, pcpKeyName string, public, createData, createAttest, 
 		createData:        createData,
 		createAttestation: createAttest,
 		createSignature:   createSig,
-		publicKey:         pubKey,
-	}, nil
-}
-
-func (k *key20) Public() crypto.PublicKey {
-	return k.publicKey
+	}
 }
 
 // Marshal represents the key in a persistent format which may be

--- a/attest/tpm_linux.go
+++ b/attest/tpm_linux.go
@@ -274,11 +274,7 @@ func (t *TPM) MintAIK(opts *MintOptions) (*AIK, error) {
 		if err != nil {
 			return nil, fmt.Errorf("CreateAIK failed: %v", err)
 		}
-		aik, err := newKey12(blob, pub)
-		if err != nil {
-			return nil, fmt.Errorf("")
-		}
-		return &AIK{aik: aik}, nil
+		return &AIK{aik: newKey12(blob, pub)}, nil
 	case TPMVersion20:
 		// TODO(jsonp): Abstract choice of hierarchy & parent.
 		srk, _, err := t.getPrimaryKeyHandle(commonSrkEquivalentHandle)
@@ -311,12 +307,7 @@ func (t *TPM) MintAIK(opts *MintOptions) (*AIK, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to pack TPMT_SIGNATURE: %v", err)
 		}
-
-		aik, err := newKey20(keyHandle, blob, pub, creationData, attestation, signature)
-		if err != nil {
-			return nil, fmt.Errorf("unpacking public key: %v", err)
-		}
-		return &AIK{aik: aik}, nil
+		return &AIK{aik: newKey20(keyHandle, blob, pub, creationData, attestation, signature)}, nil
 	default:
 		return nil, fmt.Errorf("unsupported TPM version: %x", t.version)
 	}
@@ -333,11 +324,7 @@ func (t *TPM) loadAIK(opaqueBlob []byte) (*AIK, error) {
 
 	switch sKey.TPMVersion {
 	case TPMVersion12:
-		aik, err := newKey12(sKey.Blob, sKey.Public)
-		if err != nil {
-			return nil, fmt.Errorf("unpacking aik: %v", err)
-		}
-		return &AIK{aik: aik}, nil
+		return &AIK{aik: newKey12(sKey.Blob, sKey.Public)}, nil
 	case TPMVersion20:
 		srk, _, err := t.getPrimaryKeyHandle(commonSrkEquivalentHandle)
 		if err != nil {
@@ -347,12 +334,7 @@ func (t *TPM) loadAIK(opaqueBlob []byte) (*AIK, error) {
 		if hnd, _, err = tpm2.Load(t.rwc, srk, "", sKey.Public, sKey.Blob); err != nil {
 			return nil, fmt.Errorf("Load() failed: %v", err)
 		}
-
-		aik, err := newKey20(hnd, sKey.Blob, sKey.Public, sKey.CreateData, sKey.CreateAttestation, sKey.CreateSignature)
-		if err != nil {
-			return nil, fmt.Errorf("unpacking aik: %v", err)
-		}
-		return &AIK{aik: aik}, nil
+		return &AIK{aik: newKey20(hnd, sKey.Blob, sKey.Public, sKey.CreateData, sKey.CreateAttestation, sKey.CreateSignature)}, nil
 	default:
 		return nil, fmt.Errorf("cannot load AIK with TPM version: %v", sKey.TPMVersion)
 	}

--- a/attest/tpm_windows.go
+++ b/attest/tpm_windows.go
@@ -311,17 +311,9 @@ func (t *TPM) MintAIK(opts *MintOptions) (*AIK, error) {
 
 	switch t.version {
 	case TPMVersion12:
-		aik, err := newKey12(kh, name, props.RawPublic)
-		if err != nil {
-			return nil, fmt.Errorf("unpacking aik: %v", err)
-		}
-		return &AIK{aik: aik}, nil
+		return &AIK{aik: newKey12(kh, name, props.RawPublic)}, nil
 	case TPMVersion20:
-		aik, err := newKey20(kh, name, props.RawPublic, props.RawCreationData, props.RawAttest, props.RawSignature)
-		if err != nil {
-			return nil, fmt.Errorf("unpacking aik: %v", err)
-		}
-		return &AIK{aik: aik}, nil
+		return &AIK{aik: newKey20(kh, name, props.RawPublic, props.RawCreationData, props.RawAttest, props.RawSignature)}, nil
 	default:
 		return nil, fmt.Errorf("cannot handle TPM version: %v", t.version)
 	}
@@ -343,17 +335,9 @@ func (t *TPM) loadAIK(opaqueBlob []byte) (*AIK, error) {
 
 	switch t.version {
 	case TPMVersion12:
-		aik, err := newKey12(hnd, sKey.Name, sKey.Public)
-		if err != nil {
-			return nil, fmt.Errorf("unpacking aik: %v", err)
-		}
-		return &AIK{aik: aik}, nil
+		return &AIK{aik: newKey12(hnd, sKey.Name, sKey.Public)}, nil
 	case TPMVersion20:
-		aik, err := newKey20(hnd, sKey.Name, sKey.Public, sKey.CreateData, sKey.CreateAttestation, sKey.CreateSignature)
-		if err != nil {
-			return nil, fmt.Errorf("unpacking aik: %v", err)
-		}
-		return &AIK{aik: aik}, nil
+		return &AIK{aik: newKey20(hnd, sKey.Name, sKey.Public, sKey.CreateData, sKey.CreateAttestation, sKey.CreateSignature)}, nil
 	default:
 		return nil, fmt.Errorf("cannot handle TPM version: %v", t.version)
 	}


### PR DESCRIPTION
Event log parsing requires knowning both the public key and signing
parameters. Symmantically, this information should be from an
attested public key blob, not additional data passed by the client.

Move the public key parsing to the AttestationParameters instead of the
AIK. Alternative APIs might be:

```go
func (a *AttestationParameters) PublicKey() (crypto.PublicKey, error)
func (a *AttestationParameters) SignerOpts() (crypto.SignerOpts, error)
```

Or:

```go
type PublicKey struct {
    Key  crpyto.PublicKey
    Opts crypto.SignerOpts
}
func (a *AttestationParameters) PublicKey() (*PublicKey, error)
```

Or:

```
type PublicKey struct {
    Key  crpyto.PublicKey
    Opts crypto.SignerOpts
}
func ParsePublicKey(blob []byte) (*PublicKey, error)
```

Open for discussion