### PR TITLE
Add firmware version to TPMInfo for TPM 2.0 devices.

### DIFF
--- a/attest/attest.go
+++ b/attest/attest.go
@@ -224,16 +224,17 @@ var (
 
 // TPMInfo contains information about the version & interface
 // of an open TPM.
-// FWVersionMajor and FWVersionMinor describe the firmware version of
-// the TPM, but are only available for TPM 2.0 devices.
 type TPMInfo struct {
 	Version      TPMVersion
 	Interface    TPMInterface
 	VendorInfo   string
 	Manufacturer TCGVendorID
 
-	FWVersionMajor int
-	FWVersionMinor int
+	// FirmwareVersionMajor and FirmwareVersionMinor describe
+	// the firmware version of the TPM, but are only available
+	// for TPM 2.0 devices.
+	FirmwareVersionMajor int
+	FirmwareVersionMinor int
 }
 
 // probedTPM identifies a TPM device on the system, which

--- a/attest/attest.go
+++ b/attest/attest.go
@@ -224,11 +224,16 @@ var (
 
 // TPMInfo contains information about the version & interface
 // of an open TPM.
+// FWVersionMajor and FWVersionMinor describe the firmware version of
+// the TPM, but are only available for TPM 2.0 devices.
 type TPMInfo struct {
 	Version      TPMVersion
 	Interface    TPMInterface
 	VendorInfo   string
 	Manufacturer TCGVendorID
+
+	FWVersionMajor int
+	FWVersionMinor int
 }
 
 // probedTPM identifies a TPM device on the system, which

--- a/attest/tpm_linux.go
+++ b/attest/tpm_linux.go
@@ -177,8 +177,8 @@ func (t *TPM) Info() (*TPMInfo, error) {
 		t2Info, err = readTPM2VendorAttributes(t.rwc)
 		tInfo.Manufacturer = t2Info.manufacturer
 		tInfo.VendorInfo = t2Info.vendor
-		tInfo.FWVersionMajor = t2Info.fwMajor
-		tInfo.FWVersionMinor = t2Info.fwMinor
+		tInfo.FirmwareVersionMajor = t2Info.fwMajor
+		tInfo.FirmwareVersionMinor = t2Info.fwMinor
 	default:
 		return nil, fmt.Errorf("unsupported TPM version: %x", t.version)
 	}

--- a/attest/tpm_linux.go
+++ b/attest/tpm_linux.go
@@ -163,14 +163,22 @@ func readTPM12VendorAttributes(context *tspi.Context) (TCGVendorID, string, erro
 
 // Info returns information about the TPM.
 func (t *TPM) Info() (*TPMInfo, error) {
-	var manufacturer TCGVendorID
-	var vendorInfo string
+	tInfo := TPMInfo{
+		Version:   t.version,
+		Interface: t.interf,
+	}
+
 	var err error
 	switch t.version {
 	case TPMVersion12:
-		manufacturer, vendorInfo, err = readTPM12VendorAttributes(t.ctx)
+		tInfo.Manufacturer, tInfo.VendorInfo, err = readTPM12VendorAttributes(t.ctx)
 	case TPMVersion20:
-		manufacturer, vendorInfo, err = readTPM2VendorAttributes(t.rwc)
+		var t2Info tpm20Info
+		t2Info, err = readTPM2VendorAttributes(t.rwc)
+		tInfo.Manufacturer = t2Info.manufacturer
+		tInfo.VendorInfo = t2Info.vendor
+		tInfo.FWVersionMajor = t2Info.fwMajor
+		tInfo.FWVersionMinor = t2Info.fwMinor
 	default:
 		return nil, fmt.Errorf("unsupported TPM version: %x", t.version)
 	}
@@ -178,12 +186,7 @@ func (t *TPM) Info() (*TPMInfo, error) {
 		return nil, err
 	}
 
-	return &TPMInfo{
-		Version:      t.version,
-		Interface:    t.interf,
-		VendorInfo:   vendorInfo,
-		Manufacturer: manufacturer,
-	}, nil
+	return &tInfo, nil
 }
 
 // Return value: handle, whether we generated a new one, error

--- a/attest/tpm_windows.go
+++ b/attest/tpm_windows.go
@@ -140,8 +140,8 @@ func (t *TPM) Info() (*TPMInfo, error) {
 		t2Info, err = readTPM2VendorAttributes(tpm)
 		tInfo.Manufacturer = t2Info.manufacturer
 		tInfo.VendorInfo = t2Info.vendor
-		tInfo.FWVersionMajor = t2Info.fwMajor
-		tInfo.FWVersionMinor = t2Info.fwMinor
+		tInfo.FirmwareVersionMajor = t2Info.fwMajor
+		tInfo.FirmwareVersionMinor = t2Info.fwMinor
 	default:
 		return nil, fmt.Errorf("unsupported TPM version: %x", t.version)
 	}

--- a/attest/tpm_windows.go
+++ b/attest/tpm_windows.go
@@ -123,18 +123,25 @@ func readTPM12VendorAttributes(tpm io.ReadWriter) (TCGVendorID, string, error) {
 
 // Info returns information about the TPM.
 func (t *TPM) Info() (*TPMInfo, error) {
-	var manufacturer TCGVendorID
-	var vendorInfo string
-	var err error
+	tInfo := TPMInfo{
+		Version:   t.version,
+		Interface: TPMInterfaceKernelManaged,
+	}
 	tpm, err := t.pcp.TPMCommandInterface()
 	if err != nil {
 		return nil, err
 	}
+
 	switch t.version {
 	case TPMVersion12:
-		manufacturer, vendorInfo, err = readTPM12VendorAttributes(tpm)
+		tInfo.Manufacturer, tInfo.VendorInfo, err = readTPM12VendorAttributes(tpm)
 	case TPMVersion20:
-		manufacturer, vendorInfo, err = readTPM2VendorAttributes(tpm)
+		var t2Info tpm20Info
+		t2Info, err = readTPM2VendorAttributes(tpm)
+		tInfo.Manufacturer = t2Info.manufacturer
+		tInfo.VendorInfo = t2Info.vendor
+		tInfo.FWVersionMajor = t2Info.fwMajor
+		tInfo.FWVersionMinor = t2Info.fwMinor
 	default:
 		return nil, fmt.Errorf("unsupported TPM version: %x", t.version)
 	}
@@ -142,12 +149,7 @@ func (t *TPM) Info() (*TPMInfo, error) {
 		return nil, err
 	}
 
-	return &TPMInfo{
-		Version:      t.version,
-		Interface:    TPMInterfaceKernelManaged,
-		VendorInfo:   vendorInfo,
-		Manufacturer: manufacturer,
-	}, nil
+	return &tInfo, nil
 }
 
 // EKs returns the Endorsement Keys burned-in to the platform.


### PR DESCRIPTION
Not 100% on the API for this, PTAL.