### PR TITLE
Turn appropriate RSAParameter calls into function calls

### DIFF
--- a/verifier/aik.go
+++ b/verifier/aik.go
@@ -74,7 +74,7 @@ func verifyAIK20(public, creationData, attestationData, signature []byte) (*pb.A
 		if pub.RSAParameters.KeyBits < 2048 {
 			out.KeyTooSmall = true
 		}
-		out.RocaVulnerableKey = ROCAVulnerableKey(&rsa.PublicKey{N: pub.RSAParameters.Modulus})
+		out.RocaVulnerableKey = ROCAVulnerableKey(&rsa.PublicKey{N: pub.RSAParameters.Modulus()})
 	default:
 		return nil, fmt.Errorf("public key of alg 0x%x not supported", pub.Type)
 	}
@@ -109,7 +109,7 @@ func verifyAIK20(public, creationData, attestationData, signature []byte) (*pb.A
 	out.NameAttestationMismatch = !match
 
 	// Check the signature over the attestation data verifies correctly.
-	p := rsa.PublicKey{E: int(pub.RSAParameters.Exponent), N: pub.RSAParameters.Modulus}
+	p := rsa.PublicKey{E: int(pub.RSAParameters.Exponent()), N: pub.RSAParameters.Modulus()}
 	signHashConstructor, err := pub.RSAParameters.Sign.Hash.HashConstructor()
 	if err != nil {
 		return nil, err

--- a/verifier/quote.go
+++ b/verifier/quote.go
@@ -79,7 +79,7 @@ func VerifyQuote(tpmVersion tpb.TpmVersion, public, attestationData, signature [
 		pcrDigestMatched = bytes.Equal(compositeDigest.Sum(nil), digest)
 
 		// Check the signature over the attestation data verifies correctly.
-		p := rsa.PublicKey{E: int(pub.RSAParameters.Exponent), N: pub.RSAParameters.Modulus}
+		p := rsa.PublicKey{E: int(pub.RSAParameters.Exponent()), N: pub.RSAParameters.Modulus()}
 		signHashConstructor, err := pub.RSAParameters.Sign.Hash.HashConstructor()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This PR adds function calls to the verifier to fix the following errors:

```
# github.com/google/go-attestation/verifier
../go/pkg/mod/github.com/google/go-attestation@v0.0.0-20190813215338-a1822903b448/verifier/aik.go:77:60: cannot use pub.RSAParameters.Modulus (type func() *big.Int) as type *big.Int in field value
../go/pkg/mod/github.com/google/go-attestation@v0.0.0-20190813215338-a1822903b448/verifier/aik.go:112:27: cannot convert pub.RSAParameters.Exponent (type func() uint32) to type int
../go/pkg/mod/github.com/google/go-attestation@v0.0.0-20190813215338-a1822903b448/verifier/aik.go:112:57: cannot use pub.RSAParameters.Modulus (type func() *big.Int) as type *big.Int in field value
../go/pkg/mod/github.com/google/go-attestation@v0.0.0-20190813215338-a1822903b448/verifier/quote.go:82:28: cannot convert pub.RSAParameters.Exponent (type func() uint32) to type int
../go/pkg/mod/github.com/google/go-attestation@v0.0.0-20190813215338-a1822903b448/verifier/quote.go:82:58: cannot use pub.RSAParameters.Modulus (type func() *big.Int) as type *big.Int in field value
```