### PR TITLE
attest: re-work EK API

### DIFF
--- a/attest/attest.go
+++ b/attest/attest.go
@@ -156,11 +156,19 @@ type PCR struct {
 	DigestAlg crypto.Hash
 }
 
-// PlatformEK represents a burned-in Endorsement Key, and its
-// corrresponding EKCert (where present).
-type PlatformEK struct {
-	Cert   *x509.Certificate
+// EK is a burned-in endorcement key bound to a TPM. This optionally contains
+// a certificate that can chain to the TPM manufacturer.
+type EK struct {
+	// Public key of the EK.
 	Public crypto.PublicKey
+
+	// Certificate is the EK certificate for TPMs that provide it.
+	Certificate *x509.Certificate
+
+	// For Intel TPMs, Intel hosts certificates at a public URL derived from the
+	// Public key. Clients or servers can perform an HTTP GET to this URL, and
+	// use ParseEKCertificate on the response body.
+	CertificateURL string
 }
 
 // AttestationParameters describes information about a key which is necessary

--- a/attest/attest_simulated_tpm20_test.go
+++ b/attest/attest_simulated_tpm20_test.go
@@ -19,10 +19,7 @@ package attest
 import (
 	"bytes"
 	"crypto"
-	"crypto/rsa"
 	"testing"
-
-	"github.com/google/certificate-transparency-go/x509"
 
 	"github.com/google/go-tpm-tools/simulator"
 )
@@ -49,7 +46,7 @@ func TestSimTPM20EK(t *testing.T) {
 	if err != nil {
 		t.Errorf("EKs() failed: %v", err)
 	}
-	if len(eks) == 0 || (eks[0].Cert == nil && eks[0].Public == nil) {
+	if len(eks) == 0 || (eks[0].Public == nil) {
 		t.Errorf("EKs() = %v, want at least 1 EK with populated fields", eks)
 	}
 }
@@ -99,22 +96,6 @@ func TestSimTPM20AIKCreateAndLoad(t *testing.T) {
 	}
 }
 
-// chooseEKPub selects the EK public which will be activated against.
-func chooseEKPub(t *testing.T, eks []PlatformEK) crypto.PublicKey {
-	t.Helper()
-
-	for _, ek := range eks {
-		if ek.Cert != nil && ek.Cert.PublicKeyAlgorithm == x509.RSA {
-			return ek.Cert.PublicKey.(*rsa.PublicKey)
-		} else if ek.Public != nil {
-			return ek.Public
-		}
-	}
-
-	t.Skip("No suitable RSA EK found")
-	return nil
-}
-
 func TestSimTPM20ActivateCredential(t *testing.T) {
 	sim, tpm := setupSimulatedTPM(t)
 	defer sim.Close()
@@ -129,7 +110,7 @@ func TestSimTPM20ActivateCredential(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EKs() failed: %v", err)
 	}
-	ek := chooseEKPub(t, EKs)
+	ek := chooseEK(t, EKs)
 
 	ap := ActivationParameters{
 		TPMVersion: TPMVersion20,

--- a/attest/attest_test.go
+++ b/attest/attest_test.go
@@ -17,11 +17,8 @@ package attest
 import (
 	"bytes"
 	"crypto"
-	"crypto/rsa"
 	"flag"
 	"testing"
-
-	"github.com/google/certificate-transparency-go/x509"
 )
 
 var (
@@ -121,18 +118,14 @@ func TestAIKCreateAndLoad(t *testing.T) {
 }
 
 // chooseEK selects the EK public which will be activated against.
-func chooseEK(t *testing.T, eks []PlatformEK) crypto.PublicKey {
+func chooseEK(t *testing.T, eks []EK) crypto.PublicKey {
 	t.Helper()
 
 	for _, ek := range eks {
-		if ek.Cert != nil && ek.Cert.PublicKeyAlgorithm == x509.RSA {
-			return ek.Cert.PublicKey.(*rsa.PublicKey)
-		} else if ek.Public != nil {
-			return ek.Public
-		}
+		return ek.Public
 	}
 
-	t.Skip("No suitable RSA EK found")
+	t.Fatalf("No suitable EK found")
 	return nil
 }
 

--- a/attest/attest_tpm12_test.go
+++ b/attest/attest_tpm12_test.go
@@ -77,16 +77,14 @@ func TestTPM12EKs(t *testing.T) {
 	tpm := openTPM12(t)
 	defer tpm.Close()
 
-	EKs, err := tpm.EKs()
+	eks, err := tpm.EKs()
 	if err != nil {
 		t.Fatalf("Failed to get EKs: %v", err)
 	}
 
-	if len(EKs) == 0 {
+	if len(eks) == 0 {
 		t.Fatalf("EKs returned nothing")
 	}
-
-	t.Logf("EKCert Raw: %x\n", EKs[0].Cert.Raw)
 }
 
 func TestMintAIK(t *testing.T) {
@@ -151,7 +149,7 @@ func TestTPMActivateCredential(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read EKs: %v", err)
 	}
-	ek := chooseEKPub(t, EKs)
+	ek := chooseEK(t, EKs)
 
 	ap := ActivationParameters{
 		TPMVersion: TPMVersion12,

--- a/attest/pcp_windows.go
+++ b/attest/pcp_windows.go
@@ -404,7 +404,7 @@ func (h *winPCP) EKCerts() ([]*x509.Certificate, error) {
 
 	var out []*x509.Certificate
 	for _, der := range c {
-		cert, err := parseCert(der)
+		cert, err := ParseEKCertificate(der)
 		if err != nil {
 			return nil, err
 		}

--- a/attest/tpm_test.go
+++ b/attest/tpm_test.go
@@ -1,0 +1,54 @@
+package attest
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"testing"
+)
+
+// Generated using the following command:
+//
+//   openssl genrsa 2048|openssl rsa -outform PEM -pubout
+//
+var testRSAKey = mustParseRSAKey(`-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAq8zyTXCjVALZzjS8wgNH
+nAVdt4ZGM3N450xOnLplx/RbCVwXyu83SWh0B3Ka+92aocqcHzo+j6e6Urppre/I
++7VVKTdUAr8t5gxgSLGvo+ev+zv70GF4DmJthb8JNheHCmk3RnoSFs5TnDuSdvGb
+KcSzas0186LQyxvwfFjTxLweGrZKh/CTewD0/f5ozXmbTtJpl+qYrMi9GJamGlg6
+N6EsWKh1xos8J/cEmS2vbyCGGADyBwRV8Zkto5EU1HJaEli10HVZf0D06vuKzzxM
++6W7LzGqzAPeaWvHi07ezShqdr5q5y1KKhFJcy8HOpwN8iFfIw70y3FtMlrMprrU
+twIDAQAB
+-----END PUBLIC KEY-----`)
+
+func mustParseRSAKey(data string) *rsa.PublicKey {
+	pub, err := parseRSAKey(data)
+	if err != nil {
+		panic(err)
+	}
+	return pub
+}
+
+func parseRSAKey(data string) (*rsa.PublicKey, error) {
+	b, _ := pem.Decode([]byte(data))
+	if b == nil {
+		return nil, fmt.Errorf("failed to parse PEM key")
+	}
+	pub, err := x509.ParsePKIXPublicKey(b.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing public key: %v", err)
+	}
+	if rsaPub, ok := pub.(*rsa.PublicKey); ok {
+		return rsaPub, nil
+	}
+	return nil, fmt.Errorf("expected *rsa.PublicKey, got %T", pub)
+}
+
+func TestIntelEKURL(t *testing.T) {
+	want := "https://ekop.intel.com/ekcertservice/7YtWV2nT3LpvSCfJt7ENIznN1R1jYkj_3S6mez3yyzg="
+	got := intelEKURL(testRSAKey)
+	if got != want {
+		t.Fatalf("intelEKURL(), got=%q, want=%q", got, want)
+	}
+}


### PR DESCRIPTION
This PR adds:
* Renames 'PlatformEK' to 'EK'
* More consistant support of EKs without certificates
* Removes HTTP GET to Intel EK certificate service
* Always populates EK.Public

Closes #78
Closes #74
Updates #63