### PR TITLE
attest: rename MintAIK and MintOptions to NewAIK and AIKConfig

### DIFF
--- a/attest/attest-tool/attest-tool.go
+++ b/attest/attest-tool/attest-tool.go
@@ -64,7 +64,7 @@ func runCommand(tpm *attest.TPM) error {
 		fmt.Printf("Manufactorer: %v\n", info.Manufacturer)
 
 	case "make-aik":
-		k, err := tpm.MintAIK(nil)
+		k, err := tpm.NewAIK(nil)
 		if err != nil {
 			return fmt.Errorf("failed to mint an AIK: %v", err)
 		}
@@ -186,7 +186,7 @@ func runDump(tpm *attest.TPM) (*internal.Dump, error) {
 		return nil, err
 	}
 
-	k, err := tpm.MintAIK(nil)
+	k, err := tpm.NewAIK(nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to mint an AIK: %v", err)
 	}

--- a/attest/attest.go
+++ b/attest/attest.go
@@ -129,9 +129,9 @@ func (k *AIK) AttestationParameters() AttestationParameters {
 	return k.aik.AttestationParameters()
 }
 
-// MintOptions encapsulates parameters for minting keys. This type is defined
+// AIKConfig encapsulates parameters for minting keys. This type is defined
 // now (despite being empty) for future interface compatibility.
-type MintOptions struct {
+type AIKConfig struct {
 }
 
 // EncryptedCredential represents encrypted parameters which must be activated

--- a/attest/attest_simulated_tpm20_test.go
+++ b/attest/attest_simulated_tpm20_test.go
@@ -64,9 +64,9 @@ func TestSimTPM20AIKCreateAndLoad(t *testing.T) {
 	sim, tpm := setupSimulatedTPM(t)
 	defer sim.Close()
 
-	aik, err := tpm.MintAIK(nil)
+	aik, err := tpm.NewAIK(nil)
 	if err != nil {
-		t.Fatalf("MintAIK() failed: %v", err)
+		t.Fatalf("NewAIK() failed: %v", err)
 	}
 
 	enc, err := aik.Marshal()
@@ -97,9 +97,9 @@ func TestSimTPM20ActivateCredential(t *testing.T) {
 	sim, tpm := setupSimulatedTPM(t)
 	defer sim.Close()
 
-	aik, err := tpm.MintAIK(nil)
+	aik, err := tpm.NewAIK(nil)
 	if err != nil {
-		t.Fatalf("MintAIK() failed: %v", err)
+		t.Fatalf("NewAIK() failed: %v", err)
 	}
 	defer aik.Close(tpm)
 
@@ -134,9 +134,9 @@ func TestParseAIKPublic20(t *testing.T) {
 	sim, tpm := setupSimulatedTPM(t)
 	defer sim.Close()
 
-	aik, err := tpm.MintAIK(nil)
+	aik, err := tpm.NewAIK(nil)
 	if err != nil {
-		t.Fatalf("MintAIK() failed: %v", err)
+		t.Fatalf("NewAIK() failed: %v", err)
 	}
 	defer aik.Close(tpm)
 	params := aik.AttestationParameters()
@@ -149,9 +149,9 @@ func TestSimTPM20Quote(t *testing.T) {
 	sim, tpm := setupSimulatedTPM(t)
 	defer sim.Close()
 
-	aik, err := tpm.MintAIK(nil)
+	aik, err := tpm.NewAIK(nil)
 	if err != nil {
-		t.Fatalf("MintAIK() failed: %v", err)
+		t.Fatalf("NewAIK() failed: %v", err)
 	}
 	defer aik.Close(tpm)
 

--- a/attest/attest_test.go
+++ b/attest/attest_test.go
@@ -88,9 +88,9 @@ func TestAIKCreateAndLoad(t *testing.T) {
 	}
 	defer tpm.Close()
 
-	aik, err := tpm.MintAIK(nil)
+	aik, err := tpm.NewAIK(nil)
 	if err != nil {
-		t.Fatalf("MintAIK() failed: %v", err)
+		t.Fatalf("NewAIK() failed: %v", err)
 	}
 
 	enc, err := aik.Marshal()

--- a/attest/attest_tpm12_test.go
+++ b/attest/attest_tpm12_test.go
@@ -87,13 +87,13 @@ func TestTPM12EKs(t *testing.T) {
 	}
 }
 
-func TestMintAIK(t *testing.T) {
+func TestNewAIK(t *testing.T) {
 	tpm := openTPM12(t)
 	defer tpm.Close()
 
-	aik, err := tpm.MintAIK(nil)
+	aik, err := tpm.NewAIK(nil)
 	if err != nil {
-		t.Fatalf("MintAIK failed: %v", err)
+		t.Fatalf("NewAIK failed: %v", err)
 	}
 	k := aik.aik.(*key12)
 	t.Logf("aik blob: %x\naik pubkey: %x\n", k.blob, k.public)
@@ -108,9 +108,9 @@ func TestTPMQuote(t *testing.T) {
 		t.Fatalf("reading nonce: %v", err)
 	}
 
-	aik, err := tpm.MintAIK(nil)
+	aik, err := tpm.NewAIK(nil)
 	if err != nil {
-		t.Fatalf("MintAIK failed: %v", err)
+		t.Fatalf("NewAIK failed: %v", err)
 	}
 
 	quote, err := aik.Quote(tpm, nonce, HashSHA1)
@@ -125,9 +125,9 @@ func TestParseAIKPublic12(t *testing.T) {
 	tpm := openTPM12(t)
 	defer tpm.Close()
 
-	aik, err := tpm.MintAIK(nil)
+	aik, err := tpm.NewAIK(nil)
 	if err != nil {
-		t.Fatalf("MintAIK() failed: %v", err)
+		t.Fatalf("NewAIK() failed: %v", err)
 	}
 	defer aik.Close(tpm)
 	params := aik.AttestationParameters()
@@ -140,9 +140,9 @@ func TestTPMActivateCredential(t *testing.T) {
 	tpm := openTPM12(t)
 	defer tpm.Close()
 
-	aik, err := tpm.MintAIK(nil)
+	aik, err := tpm.NewAIK(nil)
 	if err != nil {
-		t.Fatalf("MintAIK failed: %v", err)
+		t.Fatalf("NewAIK failed: %v", err)
 	}
 
 	EKs, err := tpm.EKs()

--- a/attest/example_test.go
+++ b/attest/example_test.go
@@ -21,7 +21,7 @@ func ExampleAIK() {
 	defer tpm.Close()
 
 	// Create a new AIK.
-	aik, err := tpm.MintAIK(nil)
+	aik, err := tpm.NewAIK(nil)
 	if err != nil {
 		log.Fatalf("Failed to create AIK: %v", err)
 	}
@@ -53,7 +53,7 @@ func ExampleAIK_credentialActivation() {
 	defer tpm.Close()
 
 	// Create a new AIK.
-	aik, err := tpm.MintAIK(nil)
+	aik, err := tpm.NewAIK(nil)
 	if err != nil {
 		log.Fatalf("Failed to create AIK: %v", err)
 	}
@@ -99,7 +99,7 @@ func ExampleAIK_quote() {
 	defer tpm.Close()
 
 	// Create a new AIK.
-	aik, err := tpm.MintAIK(nil)
+	aik, err := tpm.NewAIK(nil)
 	if err != nil {
 		log.Fatalf("Failed to create AIK: %v", err)
 	}

--- a/attest/pcp_windows.go
+++ b/attest/pcp_windows.go
@@ -452,8 +452,8 @@ func getPCPCerts(hProv uintptr, propertyName string) ([][]byte, error) {
 	return out, nil
 }
 
-// MintAIK creates a persistent attestation key of the specified name.
-func (h *winPCP) MintAIK(name string) (uintptr, error) {
+// NewAIK creates a persistent attestation key of the specified name.
+func (h *winPCP) NewAIK(name string) (uintptr, error) {
 	var kh uintptr
 	utf16Name, err := windows.UTF16FromString(name)
 	if err != nil {

--- a/attest/tpm_linux.go
+++ b/attest/tpm_linux.go
@@ -270,8 +270,8 @@ func (t *TPM) EKs() ([]EK, error) {
 	}
 }
 
-// MintAIK creates an attestation key.
-func (t *TPM) MintAIK(opts *MintOptions) (*AIK, error) {
+// NewAIK creates an attestation key.
+func (t *TPM) NewAIK(opts *AIKConfig) (*AIK, error) {
 	switch t.version {
 	case TPMVersion12:
 		pub, blob, err := attestation.CreateAIK(t.ctx)

--- a/attest/tpm_windows.go
+++ b/attest/tpm_windows.go
@@ -269,16 +269,16 @@ func decryptCredential(secretKey, blob []byte) ([]byte, error) {
 	return secret, nil
 }
 
-// MintAIK creates a persistent attestation key. The returned key must be
+// NewAIK creates a persistent attestation key. The returned key must be
 // closed with a call to key.Close() when the caller has finished using it.
-func (t *TPM) MintAIK(opts *MintOptions) (*AIK, error) {
+func (t *TPM) NewAIK(opts *AIKConfig) (*AIK, error) {
 	nameHex := make([]byte, 5)
 	if n, err := rand.Read(nameHex); err != nil || n != len(nameHex) {
 		return nil, fmt.Errorf("rand.Read() failed with %d/%d bytes read and error: %v", n, len(nameHex), err)
 	}
 	name := fmt.Sprintf("aik-%x", nameHex)
 
-	kh, err := t.pcp.MintAIK(name)
+	kh, err := t.pcp.NewAIK(name)
 	if err != nil {
 		return nil, fmt.Errorf("pcp failed to mint attestation key: %v", err)
 	}


### PR DESCRIPTION
This helps the godoc read better and is more inline with Go's naming
scheme. No functional changes made, just naming.

Closes #63