### PR TITLE
#85 Separate quote verification from EventLog API

### DIFF
--- a/attest/attest.go
+++ b/attest/attest.go
@@ -253,6 +253,25 @@ func ParseAIKPublic(version TPMVersion, public []byte) (*AIKPublic, error) {
 	}
 }
 
+// Verify is used to prove authenticity of the PCR measurements. It ensures that
+// the quote was signed by the AIK, and that its contents matches the PCR and
+// nonce combination.
+//
+// The nonce is used to prevent replays of Quote and PCRs and is signed by the
+// quote. Some TPMs don't support nonces longer than 20 bytes, and if the
+// nonce is used to tie additional data to the quote, the additional data should be
+// hashed to construct the nonce.
+func (a *AIKPublic) Verify(quote Quote, pcrs []PCR, nonce []byte) error {
+	switch quote.Version {
+	case TPMVersion12:
+		return a.validate12Quote(quote, pcrs, nonce)
+	case TPMVersion20:
+		return a.validate20Quote(quote, pcrs, nonce)
+	default:
+		return fmt.Errorf("quote used unknown tpm version 0x%x", quote.Version)
+	}
+}
+
 // HashAlg identifies a hashing Algorithm.
 type HashAlg uint8
 

--- a/attest/eventlog_test.go
+++ b/attest/eventlog_test.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
 package attest
 
 import (
@@ -85,20 +99,19 @@ func testEventLog(t *testing.T, testdata string) {
 	if err != nil {
 		t.Fatalf("parsing AIK: %v", err)
 	}
-
-	el := EventLog{
-		AIKPublic: aik.Public,
-		AIKHash:   aik.Hash,
-		Quote: &Quote{
-			Version:   dump.Static.TPMVersion,
-			Quote:     dump.Quote.Quote,
-			Signature: dump.Quote.Signature,
-		},
-		Nonce:          dump.Quote.Nonce,
-		PCRs:           dump.Log.PCRs,
-		MeasurementLog: dump.Log.Raw,
+	if err := aik.Verify(Quote{
+		Version:   dump.Static.TPMVersion,
+		Quote:     dump.Quote.Quote,
+		Signature: dump.Quote.Signature,
+	}, dump.Log.PCRs, dump.Quote.Nonce); err != nil {
+		t.Fatalf("verifying quote: %v", err)
 	}
-	if _, err := el.Validate(); err != nil {
+
+	el, err := ParseEventLog(dump.Log.Raw)
+	if err != nil {
+		t.Fatalf("parsing event log: %v", err)
+	}
+	if _, err := el.Verify(dump.Log.PCRs); err != nil {
 		t.Fatalf("validating event log: %v", err)
 	}
 }


### PR DESCRIPTION
Implements API discussed in #85 

 - Quote/AIK verification removed from `EventLog.Validate()`, moved into new method `AIKPublic.Verify()`
 - Moved AIKPublic & associated verification logic into own file & test file
 - Separate AIK verification logic from event log test & put in its own test
 - Added missing license headers.