### PR TITLE
Fix 'failed to verify quote: quote used unknown tpm version 0x0'

### DIFF
--- a/attest/key_windows.go
+++ b/attest/key_windows.go
@@ -89,6 +89,7 @@ func (k *key12) Quote(t *TPM, nonce []byte, alg HashAlg) (*Quote, error) {
 		return nil, fmt.Errorf("failed to construct Quote Info: %v", err)
 	}
 	return &Quote{
+		Version:   TPMVersion12,
 		Quote:     quote,
 		Signature: sig,
 	}, nil


### PR DESCRIPTION
I manually verified the other 3 cases populate `TPMVersion` correctly.