### PR TITLE
attest: expose algorithms used in measurement log

### DIFF
--- a/attest/eventlog_test.go
+++ b/attest/eventlog_test.go
@@ -62,7 +62,7 @@ func testParseEventLog(t *testing.T, testdata string) {
 	if err := json.Unmarshal(data, &dump); err != nil {
 		t.Fatalf("parsing test data: %v", err)
 	}
-	if _, err := parseEventLog(dump.Log.Raw); err != nil {
+	if _, err := ParseEventLog(dump.Log.Raw); err != nil {
 		t.Fatalf("parsing event log: %v", err)
 	}
 }
@@ -72,7 +72,7 @@ func TestParseCryptoAgileEventLog(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reading test data: %v", err)
 	}
-	if _, err := parseEventLog(data); err != nil {
+	if _, err := ParseEventLog(data); err != nil {
 		t.Fatalf("parsing event log: %v", err)
 	}
 }

--- a/attest/tpm.go
+++ b/attest/tpm.go
@@ -307,7 +307,12 @@ func (t *TPM) NewAIK(opts *AIKConfig) (*AIK, error) {
 	return t.tpm.newAIK(opts)
 }
 
-// PCRs returns the present value of Platform Configuration Registers with the given digest algorithm.
+// PCRs returns the present value of Platform Configuration Registers with
+// the given digest algorithm.
+//
+// Use ParseEventLog to determine which algorithm to use to match the values
+// present in the event log. It's not always guarenteed that a system with TPM
+// 2.0 will extend PCRs with SHA256 digests.
 func (t *TPM) PCRs(alg HashAlg) ([]PCR, error) {
 	return t.tpm.pcrs(alg)
 }


### PR DESCRIPTION
Expose the algorithms that are used in the measurement log. This lets
clients generate PCR measurements that match their log digests.

Closes #75