### PR TITLE
Re-work eventlog replay algorithm

### DIFF
--- a/attest/eventlog_test.go
+++ b/attest/eventlog_test.go
@@ -111,7 +111,14 @@ func testEventLog(t *testing.T, testdata string) {
 	if err != nil {
 		t.Fatalf("parsing event log: %v", err)
 	}
-	if _, err := el.Verify(dump.Log.PCRs); err != nil {
+	events, err := el.Verify(dump.Log.PCRs)
+	if err != nil {
 		t.Fatalf("validating event log: %v", err)
+	}
+
+	for i, e := range events {
+		if e.sequence != i {
+			t.Errorf("event out of order: events[%d].sequence = %d, want %d", i, e.sequence, i)
+		}
 	}
 }


### PR DESCRIPTION
 - Support replaying against a set of PCRs which includes multiple values for the same index
 - Consider a specific PCR 'verified' if at least one provided PCR value matched all events
 - Verify `tpm20GeneratedMagic` in `validate20Quote()` to prevent use of `TPM2_Sign` to fake quotes