### PR TITLE
Add config struct for AttestPlatform(), to configure event log source

### DIFF
--- a/attest/attest.go
+++ b/attest/attest.go
@@ -119,6 +119,9 @@ func (k *AIK) ActivateCredential(tpm *TPM, in EncryptedCredential) (secret []byt
 }
 
 // Quote returns a quote over the platform state, signed by the AIK.
+//
+// This is a low-level API. Consumers seeking to attest the state of the
+// platform should use tpm.AttestPlatform() instead.
 func (k *AIK) Quote(tpm *TPM, nonce []byte, alg HashAlg) (*Quote, error) {
 	return k.aik.quote(tpm.tpm, nonce, alg)
 }


### PR DESCRIPTION
There are two main use-cases for this:

 - Pre-processing of the event log, such as combining the BIOS event log with a log of events extended post-boot
 - Allowing `AttestPlatform()` to succeed even if the system does not have an event log.