### PR TITLE
Target gofuzz build tag instead of cgo

### DIFF
--- a/attest/activation.go
+++ b/attest/activation.go
@@ -1,4 +1,4 @@
-// +build cgo
+// +build !gofuzz
 
 package attest
 

--- a/attest/key_linux.go
+++ b/attest/key_linux.go
@@ -12,7 +12,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-// +build linux,cgo
+// +build linux
+// +build !gofuzz
 
 package attest
 

--- a/attest/tpm_linux.go
+++ b/attest/tpm_linux.go
@@ -12,7 +12,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-// +build linux,cgo
+// +build linux
+// +build !gofuzz
 
 package attest
 

--- a/attest/tpm_other.go
+++ b/attest/tpm_other.go
@@ -12,12 +12,11 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-// +build !linux !windows
+// +build gofuzz
 
 package attest
 
 type platformTPM struct {
-	// interf TPMInterface
 }
 
 func probeSystemTPMs() ([]probedTPM, error) {


### PR DESCRIPTION
go-fuzz + libFuzzer can't be built with `CGO_ENABLED=0`.