### PR TITLE
ParseEventLog fuzz target

### DIFF
--- a/attest/activation.go
+++ b/attest/activation.go
@@ -31,21 +31,6 @@ const (
 	tpm20GeneratedMagic = 0xff544347
 )
 
-func cryptoHash(h tpm2.Algorithm) (crypto.Hash, error) {
-	switch h {
-	case tpm2.AlgSHA1:
-		return crypto.SHA1, nil
-	case tpm2.AlgSHA256:
-		return crypto.SHA256, nil
-	case tpm2.AlgSHA384:
-		return crypto.SHA384, nil
-	case tpm2.AlgSHA512:
-		return crypto.SHA512, nil
-	default:
-		return crypto.Hash(0), fmt.Errorf("unsupported signature digest: %v", h)
-	}
-}
-
 // ActivationParameters encapsulates the inputs for activating an AK.
 type ActivationParameters struct {
 	// TPMVersion holds the version of the TPM, either 1.2 or 2.0.

--- a/attest/eventlog_fuzz.go
+++ b/attest/eventlog_fuzz.go
@@ -1,0 +1,25 @@
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+// +build gofuzz
+
+package attest
+
+func FuzzParseEventLog(data []byte) int {
+	_, err := ParseEventLog(data)
+	if err != nil {
+		return 0
+	}
+	return 1
+}

--- a/attest/key_linux.go
+++ b/attest/key_linux.go
@@ -12,7 +12,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-// +build linux
+// +build linux,!gofuzz
 
 package attest
 

--- a/attest/tpm.go
+++ b/attest/tpm.go
@@ -16,6 +16,7 @@ package attest
 
 import (
 	"bytes"
+	"crypto"
 	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/base64"
@@ -97,6 +98,21 @@ var (
 		},
 	}
 )
+
+func cryptoHash(h tpm2.Algorithm) (crypto.Hash, error) {
+        switch h {
+        case tpm2.AlgSHA1:
+                return crypto.SHA1, nil
+        case tpm2.AlgSHA256:
+                return crypto.SHA256, nil
+        case tpm2.AlgSHA384:
+                return crypto.SHA384, nil
+        case tpm2.AlgSHA512:
+                return crypto.SHA512, nil
+        default:
+                return crypto.Hash(0), fmt.Errorf("unsupported signature digest: %v", h)
+        }
+}
 
 type tpm20Info struct {
 	vendor       string

--- a/attest/tpm_linux.go
+++ b/attest/tpm_linux.go
@@ -12,7 +12,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-// +build linux
+// +build linux,!gofuzz
 
 package attest
 

--- a/attest/tpm_other.go
+++ b/attest/tpm_other.go
@@ -1,0 +1,67 @@
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+// +build gofuzz !linux,!windows
+
+package attest
+
+import (
+	"errors"
+)
+
+var unsupportedError = errors.New("tpm operations not supported from given build parameters")
+
+type platformTPM struct {
+}
+
+func probeSystemTPMs() ([]probedTPM, error) {
+	return nil, unsupportedError
+}
+
+func openTPM(tpm probedTPM) (*TPM, error) {
+	return nil, unsupportedError
+}
+
+func (t *platformTPM) tpmVersion() TPMVersion {
+	return TPMVersionAgnostic
+}
+
+func (t *platformTPM) close() error {
+
+	return unsupportedError
+}
+
+func (t *platformTPM) info() (*TPMInfo, error) {
+	return nil, unsupportedError
+}
+
+func (t *platformTPM) loadAK(opaqueBlob []byte) (*AK, error) {
+	return nil, unsupportedError
+}
+
+func (t *platformTPM) eks() ([]EK, error) {
+	return nil, unsupportedError
+}
+
+func (t *platformTPM) newAK(opts *AKConfig) (*AK, error) {
+	return nil, unsupportedError
+}
+
+func (t *platformTPM) pcrs(alg HashAlg) ([]PCR, error) {
+	return nil, unsupportedError
+}
+
+func (t *platformTPM) measurementLog() ([]byte, error) {
+	return nil, unsupportedError
+}


### PR DESCRIPTION
A go-fuzz target for the ParseEventLog function. It has been tested
with go-fuzz and go-fuzz + libFuzzer.

oss-fuzz requires a statically built fuzzer binary, so `gofuzz` build
tags are added to avoid building files that depend on go-tspi. A mock
tpm_other.go file is also included to satisfy the `platformTPM`
interface.