### PR TITLE
attest: work around tpm2 removal of Algorithm.HashConstructor()

### DIFF
--- a/attest/activation.go
+++ b/attest/activation.go
@@ -121,11 +121,11 @@ func (p *ActivationParameters) checkTPM20AKParameters() error {
 
 	// Compute & verify that the creation data matches the digest in the
 	// attestation structure.
-	nameHashConstructor, err := pub.NameAlg.HashConstructor()
+	nameHash, err := pub.NameAlg.Hash()
 	if err != nil {
 		return fmt.Errorf("HashConstructor() failed: %v", err)
 	}
-	h := nameHashConstructor()
+	h := nameHash.New()
 	h.Write(p.AK.CreateData)
 	if !bytes.Equal(att.AttestedCreationInfo.OpaqueDigest, h.Sum(nil)) {
 		return errors.New("attestation refers to different public key")
@@ -161,13 +161,13 @@ func (p *ActivationParameters) checkTPM20AKParameters() error {
 
 	// Check the signature over the attestation data verifies correctly.
 	pk := rsa.PublicKey{E: int(pub.RSAParameters.Exponent()), N: pub.RSAParameters.Modulus()}
-	signHashConstructor, err := pub.RSAParameters.Sign.Hash.HashConstructor()
+	signHash, err := pub.RSAParameters.Sign.Hash.Hash()
 	if err != nil {
 		return err
 	}
-	hsh := signHashConstructor()
+	hsh := signHash.New()
 	hsh.Write(p.AK.CreateAttestation)
-	verifyHash, err := cryptoHash(pub.RSAParameters.Sign.Hash)
+	verifyHash, err := pub.RSAParameters.Sign.Hash.Hash()
 	if err != nil {
 		return err
 	}

--- a/attest/attest.go
+++ b/attest/attest.go
@@ -241,9 +241,9 @@ func ParseAKPublic(version TPMVersion, public []byte) (*AKPublic, error) {
 		var h crypto.Hash
 		switch pub.Type {
 		case tpm2.AlgRSA:
-			h, err = cryptoHash(pub.RSAParameters.Sign.Hash)
+			h, err = pub.RSAParameters.Sign.Hash.Hash()
 		case tpm2.AlgECC:
-			h, err = cryptoHash(pub.ECCParameters.Sign.Hash)
+			h, err = pub.ECCParameters.Sign.Hash.Hash()
 		default:
 			return nil, fmt.Errorf("unsupported public key type 0x%x", pub.Type)
 		}

--- a/attest/tpm.go
+++ b/attest/tpm.go
@@ -16,7 +16,6 @@ package attest
 
 import (
 	"bytes"
-	"crypto"
 	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/base64"
@@ -98,21 +97,6 @@ var (
 		},
 	}
 )
-
-func cryptoHash(h tpm2.Algorithm) (crypto.Hash, error) {
-	switch h {
-	case tpm2.AlgSHA1:
-		return crypto.SHA1, nil
-	case tpm2.AlgSHA256:
-		return crypto.SHA256, nil
-	case tpm2.AlgSHA384:
-		return crypto.SHA384, nil
-	case tpm2.AlgSHA512:
-		return crypto.SHA512, nil
-	default:
-		return crypto.Hash(0), fmt.Errorf("unsupported signature digest: %v", h)
-	}
-}
 
 type tpm20Info struct {
 	vendor       string

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/google/certificate-transparency-go v1.0.22-0.20190605205155-41fc2ef3a2a8
-	github.com/google/go-tpm v0.2.1-0.20190919221813-f772099985c3
+	github.com/google/go-tpm v0.2.1-0.20191015210219-431489f43254
 	github.com/google/go-tpm-tools v0.1.1
 	github.com/google/go-tspi v0.2.1-0.20190423175329-115dea689aad
 	golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/google/go-tpm v0.1.2-0.20190725015402-ae6dd98980d4/go.mod h1:H9HbmUG2
 github.com/google/go-tpm v0.2.1-0.20190910203116-33a9c3f38379/go.mod h1:gTv8GNuqS7CI+tQWrpt5BMMaD5W3G+dZULQLhhAKT5c=
 github.com/google/go-tpm v0.2.1-0.20190919221813-f772099985c3 h1:VJTqpj8yU29QGqBMAHEuGukOS4PfKAum5FKXoHsbUj0=
 github.com/google/go-tpm v0.2.1-0.20190919221813-f772099985c3/go.mod h1:gTv8GNuqS7CI+tQWrpt5BMMaD5W3G+dZULQLhhAKT5c=
+github.com/google/go-tpm v0.2.1-0.20191015210219-431489f43254 h1:ahwXCP5Ui0eYBO9nM71/BzWwVtnGjfZ4OsnDE0V2pMA=
+github.com/google/go-tpm v0.2.1-0.20191015210219-431489f43254/go.mod h1:gTv8GNuqS7CI+tQWrpt5BMMaD5W3G+dZULQLhhAKT5c=
 github.com/google/go-tpm-tools v0.0.0-20190906225433-1614c142f845/go.mod h1:AVfHadzbdzHo54inR2x1v640jdi1YSi3NauM2DUsxk0=
 github.com/google/go-tpm-tools v0.1.1 h1:oxbHulx5A+yHrJW6DdEuATED1ixTswHyldrbC8fdFlw=
 github.com/google/go-tpm-tools v0.1.1/go.mod h1:gIwN0GIUFk8cgICog9SxSknHh4hmLrQApJfB5Ssft7g=


### PR DESCRIPTION
go-tpm removed HashConstructor in favor of Hash breaking our build at
tip. To ensure go-attestation works with as many versions of go-tpm as
possible, switch to our internal method for converting a tpm2.Algorithm
to a crypto.Hash (instead of using the new Algorithm.Hash()).

https://github.com/google/go-tpm/commit/431489f432542ec0b7acd4a5c9b8dbbde56f2869