### PR TITLE
attest: add code for turning the AK into a signer

### DIFF
--- a/attest/attest.go
+++ b/attest/attest.go
@@ -90,6 +90,7 @@ type ak interface {
 	activateCredential(tpm *platformTPM, in EncryptedCredential) ([]byte, error)
 	quote(t *platformTPM, nonce []byte, alg HashAlg) (*Quote, error)
 	attestationParameters() AttestationParameters
+	privateKey() crypto.PrivateKey
 }
 
 // AK represents a key which can be used for attestation.
@@ -130,6 +131,12 @@ func (k *AK) Quote(tpm *TPM, nonce []byte, alg HashAlg) (*Quote, error) {
 // generate a credential activation challenge.
 func (k *AK) AttestationParameters() AttestationParameters {
 	return k.ak.attestationParameters()
+}
+
+// PrivateKey returns a private key that implements crypto.Signer and/or
+// crypto.Decrypter.
+func (k *AK) PrivateKey() crypto.PrivateKey {
+	return k.ak.privateKey()
 }
 
 // AKConfig encapsulates parameters for minting keys. This type is defined

--- a/attest/signer.go
+++ b/attest/signer.go
@@ -1,0 +1,128 @@
+package attest
+
+import (
+	"crypto"
+	"crypto/rsa"
+	"encoding/asn1"
+	"fmt"
+	"io"
+	"math/big"
+
+	"github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/tpmutil"
+)
+
+var tpm2HashFuncMap = map[crypto.Hash]tpm2.Algorithm{
+	crypto.SHA1:   tpm2.AlgSHA1,
+	crypto.SHA256: tpm2.AlgSHA256,
+	crypto.SHA384: tpm2.AlgSHA384,
+	crypto.SHA512: tpm2.AlgSHA512,
+}
+
+func tpm2HashFunc(h crypto.Hash) (tpm2.Algorithm, error) {
+	if a, ok := tpm2HashFuncMap[h]; ok {
+		return a, nil
+	}
+	return 0, fmt.Errorf("unsupported hash algorithm 0x%x", h)
+}
+
+type ec20Key struct {
+	tpm    io.ReadWriter
+	handle tpmutil.Handle
+	pub    crypto.PublicKey
+}
+
+type ecdsaSignature struct {
+	R, S *big.Int
+}
+
+func (k *ec20Key) Public() crypto.PublicKey {
+	return k.pub
+}
+
+func (k *ec20Key) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	hash, err := tpm2HashFunc(opts.HashFunc())
+	if err != nil {
+		return nil, err
+	}
+	scheme := &tpm2.SigScheme{Hash: hash, Alg: tpm2.AlgECDSA}
+	sig, err := tpm2.Sign(k.tpm, k.handle, akDefaultOwnerPassword, digest, scheme)
+	if err != nil {
+		return nil, fmt.Errorf("signing failed: %v", err)
+	}
+	if sig.ECC == nil {
+		return nil, fmt.Errorf("signing operation didn't return a signature")
+	}
+	// See: https://golang.org/src/crypto/ecdsa/ecdsa.go
+	return asn1.Marshal(ecdsaSignature{sig.ECC.R, sig.ECC.S})
+}
+
+type rsa20Key struct {
+	tpm    io.ReadWriter
+	handle tpmutil.Handle
+	pub    crypto.PublicKey
+}
+
+func (k *rsa20Key) Public() crypto.PublicKey {
+	return k.pub
+}
+
+type sigErr struct {
+	scheme *tpm2.SigScheme
+	err    error
+}
+
+func (s *sigErr) Error() string {
+	return fmt.Sprintf("signing with scheme %#v failed: %v", s.scheme, s.err)
+}
+
+func (k *rsa20Key) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	hash, err := tpm2HashFunc(opts.HashFunc())
+	if err != nil {
+		return nil, err
+	}
+	// TODO(ericchiang): support PSS
+	scheme := &tpm2.SigScheme{Hash: hash, Alg: tpm2.AlgRSASSA}
+	sig, err := tpm2.Sign(k.tpm, k.handle, akDefaultOwnerPassword, digest, scheme)
+	if err != nil {
+		return nil, &sigErr{scheme, err}
+	}
+	if sig.RSA == nil {
+		return nil, &sigErr{scheme, fmt.Errorf("tpm sign command didn't return a signature")}
+	}
+	return []byte(sig.RSA.Signature), nil
+}
+
+func (k *rsa20Key) Decrypt(rand io.Reader, msg []byte, opts crypto.DecrypterOpts) ([]byte, error) {
+	var alg tpm2.Algorithm
+	label := ""
+	switch opts := opts.(type) {
+	case *rsa.OAEPOptions:
+		alg = tpm2.AlgOAEP
+		label = string(opts.Label)
+	case nil:
+		alg = tpm2.AlgOAEP
+	case *rsa.PKCS1v15DecryptOptions:
+		alg = tpm2.AlgRSAES
+	default:
+		return nil, fmt.Errorf("unsupported decryption options: %T", opts)
+	}
+	scheme := &tpm2.AsymScheme{Alg: alg}
+	return tpm2.RSADecrypt(k.tpm, k.handle, akDefaultOwnerPassword, msg, scheme, label)
+}
+
+type rsa12Key struct {
+	pub crypto.PublicKey
+}
+
+func (k *rsa12Key) Public() crypto.PublicKey {
+	return k.pub
+}
+
+func (k *rsa12Key) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	return nil, fmt.Errorf("signing not supported for tpm 1.2")
+}
+
+func (k *rsa12Key) Decrypt(rand io.Reader, msg []byte, opts crypto.DecrypterOpts) ([]byte, error) {
+	return nil, fmt.Errorf("decrypt not supported for tpm 1.2")
+}

--- a/attest/signer_test.go
+++ b/attest/signer_test.go
@@ -1,0 +1,9 @@
+package attest
+
+import "crypto"
+
+var (
+	_ = (crypto.Decrypter)(&rsa20Key{})
+	_ = (crypto.Signer)(&rsa20Key{})
+	_ = (crypto.Signer)(&ec20Key{})
+)

--- a/attest/tpm.go
+++ b/attest/tpm.go
@@ -42,6 +42,12 @@ const (
 	// Defined in "Registry of reserved TPM 2.0 handles and localities", and checked on a glinux machine.
 	commonSrkEquivalentHandle = 0x81000001
 	commonEkEquivalentHandle  = 0x81010001
+
+	// Default passwords for the AK, an empty password. Since AKs are bound to a
+	// single TPM, passwords provide additional hardening on a running system, but
+	// for now an empty one is reasonable.
+	akDefaultParentPassword = ""
+	akDefaultOwnerPassword  = ""
 )
 
 var (


### PR DESCRIPTION
The added test currently fails with the following error message:

    === RUN   TestSimTPM20RSASign
    --- FAIL: TestSimTPM20RSASign (0.10s)
        attest_simulated_tpm20_test.go:291: signing failed: signing with scheme &tpm2.SigScheme{Alg:0x14, Hash:0xb, Count:0x0} failed: parameter 3, error code 0x20 : invalid ticket

"invalid ticket" would appear to imply that the hash algorithm isn't the
one specified in the key scheme[1]. Overall I'm kinda confused.

[1] https://trustedcomputinggroup.org/wp-content/uploads/TPM-Rev-2.0-Part-3-Commands-01.38-code.pdf#page=204