### PR TITLE
Validate signature scheme is present when decoding TPMT_PUBLIC blobs

### DIFF
--- a/attest/attest.go
+++ b/attest/attest.go
@@ -234,10 +234,20 @@ func ParseAKPublic(version TPMVersion, public []byte) (*AKPublic, error) {
 		if err != nil {
 			return nil, fmt.Errorf("parsing TPM public key structure: %v", err)
 		}
+		switch {
+		case pub.RSAParameters == nil && pub.ECCParameters == nil:
+			return nil, errors.New("parsing public key: missing asymmetric parameters")
+		case pub.RSAParameters != nil && pub.RSAParameters.Sign == nil:
+			return nil, errors.New("parsing public key: missing rsa signature scheme")
+		case pub.ECCParameters != nil && pub.ECCParameters.Sign == nil:
+			return nil, errors.New("parsing public key: missing ecc signature scheme")
+		}
+
 		pubKey, err := pub.Key()
 		if err != nil {
 			return nil, fmt.Errorf("parsing public key: %v", err)
 		}
+
 		var h crypto.Hash
 		switch pub.Type {
 		case tpm2.AlgRSA:

--- a/attest/attest_test.go
+++ b/attest/attest_test.go
@@ -152,3 +152,14 @@ func TestPCRs(t *testing.T) {
 		}
 	}
 }
+
+func TestBug139(t *testing.T) {
+	// Tests ParseAKPublic() with known parseable but non-spec-compliant blobs, and ensure
+	// an error is returned rather than a segfault.
+	// https://github.com/google/go-attestation/issues/139
+	badBlob := []byte{0, 1, 0, 4, 0, 1, 0, 0, 0, 0, 0, 6, 0, 128, 0, 67, 0, 16, 8, 0, 0, 1, 0, 1, 0, 0}
+	msg := "parsing public key: missing rsa signature scheme"
+	if _, err := ParseAKPublic(TPMVersion20, badBlob); err == nil || err.Error() != msg {
+		t.Errorf("ParseAKPublic() err = %v, want %v", err, msg)
+	}
+}


### PR DESCRIPTION
Fixes #139 