### PR TITLE
Add CommandChannel to OpenConfig to support downstream simulator

### DIFF
--- a/attest/attest_simulated_tpm20_test.go
+++ b/attest/attest_simulated_tpm20_test.go
@@ -29,16 +29,18 @@ import (
 
 func setupSimulatedTPM(t *testing.T) (*simulator.Simulator, *TPM) {
 	t.Helper()
-	tpm, err := simulator.Get()
+	sim, err := simulator.Get()
 	if err != nil {
 		t.Fatal(err)
 	}
-	return tpm, &TPM{tpm: &platformTPM{
-		version: TPMVersion20,
-		interf:  TPMInterfaceKernelManaged,
-		sysPath: "/dev/tpmrm0",
-		rwc:     tpm,
-	}}
+	tpm, err := OpenTPM(&OpenConfig{
+		TPMVersion:     TPMVersion20,
+		CommandChannel: sim,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sim, tpm
 }
 
 func TestSimTPM20EK(t *testing.T) {

--- a/attest/attest_tpm12_test.go
+++ b/attest/attest_tpm12_test.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	testTPM12   = flag.Bool("testTPM12", false, "run tests for TPM1.2")
-	tpm12config = &OpenConfig{TPMVersion12}
+	tpm12config = &OpenConfig{TPMVersion: TPMVersion12}
 )
 
 func openTPM12(t *testing.T) *TPM {

--- a/attest/key.go
+++ b/attest/key.go
@@ -1,0 +1,107 @@
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package attest
+
+import (
+	"fmt"
+
+	"github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/tpmutil"
+)
+
+// key20 represents a key bound to a TPM 2.0.
+type key20 struct {
+	hnd tpmutil.Handle
+
+	blob              []byte
+	public            []byte // used by both TPM1.2 and 2.0
+	createData        []byte
+	createAttestation []byte
+	createSignature   []byte
+}
+
+func newKey20(hnd tpmutil.Handle, blob, public, createData, createAttestation, createSig []byte) ak {
+	return &key20{
+		hnd:               hnd,
+		blob:              blob,
+		public:            public,
+		createData:        createData,
+		createAttestation: createAttestation,
+		createSignature:   createSig,
+	}
+}
+
+func (k *key20) marshal() ([]byte, error) {
+	return (&serializedKey{
+		Encoding:   keyEncodingEncrypted,
+		TPMVersion: TPMVersion20,
+
+		Blob:              k.blob,
+		Public:            k.public,
+		CreateData:        k.createData,
+		CreateAttestation: k.createAttestation,
+		CreateSignature:   k.createSignature,
+	}).Serialize()
+}
+
+func (k *key20) close(t interface{}) error {
+	tpm, _ := t.(*selectorTPM)
+	return tpm2.FlushContext(tpm.rwc, k.hnd)
+}
+
+func (k *key20) activateCredential(t interface{}, in EncryptedCredential) ([]byte, error) {
+	tpm, _ := t.(*selectorTPM)
+	ekHnd, _, err := tpm.getPrimaryKeyHandle(commonEkEquivalentHandle)
+	if err != nil {
+		return nil, err
+	}
+
+	sessHandle, _, err := tpm2.StartAuthSession(
+		tpm.rwc,
+		tpm2.HandleNull,  /*tpmKey*/
+		tpm2.HandleNull,  /*bindKey*/
+		make([]byte, 16), /*nonceCaller*/
+		nil,              /*secret*/
+		tpm2.SessionPolicy,
+		tpm2.AlgNull,
+		tpm2.AlgSHA256)
+	if err != nil {
+		return nil, fmt.Errorf("creating session: %v", err)
+	}
+	defer tpm2.FlushContext(tpm.rwc, sessHandle)
+
+	if _, err := tpm2.PolicySecret(tpm.rwc, tpm2.HandleEndorsement, tpm2.AuthCommand{Session: tpm2.HandlePasswordSession, Attributes: tpm2.AttrContinueSession}, sessHandle, nil, nil, nil, 0); err != nil {
+		return nil, fmt.Errorf("tpm2.PolicySecret() failed: %v", err)
+	}
+
+	return tpm2.ActivateCredentialUsingAuth(tpm.rwc, []tpm2.AuthCommand{
+		{Session: tpm2.HandlePasswordSession, Attributes: tpm2.AttrContinueSession},
+		{Session: sessHandle, Attributes: tpm2.AttrContinueSession},
+	}, k.hnd, ekHnd, in.Credential[2:], in.Secret[2:])
+}
+
+func (k *key20) quote(t interface{}, nonce []byte, alg HashAlg) (*Quote, error) {
+	tpm, _ := t.(*selectorTPM)
+	return quote20(tpm.rwc, k.hnd, tpm2.Algorithm(alg), nonce)
+}
+
+func (k *key20) attestationParameters() AttestationParameters {
+	return AttestationParameters{
+		Public:            k.public,
+		CreateData:        k.createData,
+		CreateAttestation: k.createAttestation,
+		CreateSignature:   k.createSignature,
+	}
+}

--- a/attest/key_linux.go
+++ b/attest/key_linux.go
@@ -19,19 +19,17 @@ package attest
 import (
 	"fmt"
 
-	"github.com/google/go-tpm/tpm2"
-	"github.com/google/go-tpm/tpmutil"
 	"github.com/google/go-tspi/attestation"
 )
 
-// key12 represents a key bound to a TPM 1.2 device via tcsd.
-type key12 struct {
+// platformKey12 represents a key bound to a TPM 1.2 device via tcsd.
+type platformKey12 struct {
 	blob   []byte
 	public []byte
 }
 
-func newKey12(blob, public []byte) ak {
-	return &key12{
+func newPlatformKey12(blob, public []byte) ak {
+	return &platformKey12{
 		blob:   blob,
 		public: public,
 	}
@@ -39,7 +37,7 @@ func newKey12(blob, public []byte) ak {
 
 // Marshal represents the key in a persistent format which may be
 // loaded at a later time using tpm.LoadKey().
-func (k *key12) marshal() ([]byte, error) {
+func (k *platformKey12) marshal() ([]byte, error) {
 	out := serializedKey{
 		Encoding:   keyEncodingEncrypted,
 		TPMVersion: TPMVersion12,
@@ -49,24 +47,26 @@ func (k *key12) marshal() ([]byte, error) {
 	return out.Serialize()
 }
 
-func (k *key12) close(tpm *platformTPM) error {
+func (k *platformKey12) close(t interface{}) error {
 	return nil // No state for tpm 1.2.
 }
 
-func (k *key12) activateCredential(t *platformTPM, in EncryptedCredential) ([]byte, error) {
-	cred, err := attestation.AIKChallengeResponse(t.ctx, k.blob, in.Credential, in.Secret)
+func (k *platformKey12) activateCredential(t interface{}, in EncryptedCredential) ([]byte, error) {
+	tpm, _ := t.(*platformTPM)
+	cred, err := attestation.AIKChallengeResponse(tpm.ctx, k.blob, in.Credential, in.Secret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to activate ak: %v", err)
 	}
 	return cred, nil
 }
 
-func (k *key12) quote(t *platformTPM, nonce []byte, alg HashAlg) (*Quote, error) {
+func (k *platformKey12) quote(t interface{}, nonce []byte, alg HashAlg) (*Quote, error) {
+	tpm, _ := t.(*platformTPM)
 	if alg != HashSHA1 {
 		return nil, fmt.Errorf("only SHA1 algorithms supported on TPM 1.2, not %v", alg)
 	}
 
-	quote, rawSig, err := attestation.GetQuote(t.ctx, k.blob, nonce)
+	quote, rawSig, err := attestation.GetQuote(tpm.ctx, k.blob, nonce)
 	if err != nil {
 		return nil, fmt.Errorf("Quote() failed: %v", err)
 	}
@@ -78,91 +78,9 @@ func (k *key12) quote(t *platformTPM, nonce []byte, alg HashAlg) (*Quote, error)
 	}, nil
 }
 
-func (k *key12) attestationParameters() AttestationParameters {
+func (k *platformKey12) attestationParameters() AttestationParameters {
 	return AttestationParameters{
 		Public:                  k.public,
 		UseTCSDActivationFormat: true,
-	}
-}
-
-// key20 represents a key bound to a TPM 2.0.
-type key20 struct {
-	hnd tpmutil.Handle
-
-	blob              []byte
-	public            []byte // used by both TPM1.2 and 2.0
-	createData        []byte
-	createAttestation []byte
-	createSignature   []byte
-}
-
-func newKey20(hnd tpmutil.Handle, blob, public, createData, createAttestation, createSig []byte) ak {
-	return &key20{
-		hnd:               hnd,
-		blob:              blob,
-		public:            public,
-		createData:        createData,
-		createAttestation: createAttestation,
-		createSignature:   createSig,
-	}
-}
-
-func (k *key20) marshal() ([]byte, error) {
-	return (&serializedKey{
-		Encoding:   keyEncodingEncrypted,
-		TPMVersion: TPMVersion20,
-
-		Blob:              k.blob,
-		Public:            k.public,
-		CreateData:        k.createData,
-		CreateAttestation: k.createAttestation,
-		CreateSignature:   k.createSignature,
-	}).Serialize()
-}
-
-func (k *key20) close(tpm *platformTPM) error {
-	return tpm2.FlushContext(tpm.rwc, k.hnd)
-}
-
-func (k *key20) activateCredential(t *platformTPM, in EncryptedCredential) ([]byte, error) {
-	ekHnd, _, err := t.getPrimaryKeyHandle(commonEkEquivalentHandle)
-	if err != nil {
-		return nil, err
-	}
-
-	sessHandle, _, err := tpm2.StartAuthSession(
-		t.rwc,
-		tpm2.HandleNull,  /*tpmKey*/
-		tpm2.HandleNull,  /*bindKey*/
-		make([]byte, 16), /*nonceCaller*/
-		nil,              /*secret*/
-		tpm2.SessionPolicy,
-		tpm2.AlgNull,
-		tpm2.AlgSHA256)
-	if err != nil {
-		return nil, fmt.Errorf("creating session: %v", err)
-	}
-	defer tpm2.FlushContext(t.rwc, sessHandle)
-
-	if _, err := tpm2.PolicySecret(t.rwc, tpm2.HandleEndorsement, tpm2.AuthCommand{Session: tpm2.HandlePasswordSession, Attributes: tpm2.AttrContinueSession}, sessHandle, nil, nil, nil, 0); err != nil {
-		return nil, fmt.Errorf("tpm2.PolicySecret() failed: %v", err)
-	}
-
-	return tpm2.ActivateCredentialUsingAuth(t.rwc, []tpm2.AuthCommand{
-		{Session: tpm2.HandlePasswordSession, Attributes: tpm2.AttrContinueSession},
-		{Session: sessHandle, Attributes: tpm2.AttrContinueSession},
-	}, k.hnd, ekHnd, in.Credential[2:], in.Secret[2:])
-}
-
-func (k *key20) quote(t *platformTPM, nonce []byte, alg HashAlg) (*Quote, error) {
-	return quote20(t.rwc, k.hnd, tpm2.Algorithm(alg), nonce)
-}
-
-func (k *key20) attestationParameters() AttestationParameters {
-	return AttestationParameters{
-		Public:            k.public,
-		CreateData:        k.createData,
-		CreateAttestation: k.createAttestation,
-		CreateSignature:   k.createSignature,
 	}
 }

--- a/attest/tpm.go
+++ b/attest/tpm.go
@@ -271,7 +271,7 @@ func readAllPCRs20(tpm io.ReadWriter, alg tpm2.Algorithm) (map[uint32][]byte, er
 type TPM struct {
 	// tpm holds a platform specific implementation of TPM logic: Windows or Linux.
 	// see *_linux.go and *_windows.go files for definitions of these structs.
-	tpm *platformTPM
+	tpm *selectorTPM
 }
 
 // Close shuts down the connection to the TPM.
@@ -300,7 +300,8 @@ func (t *TPM) LoadAK(opaqueBlob []byte) (*AK, error) {
 // MeasurementLog returns the present value of the System Measurement Log.
 //
 // This is a low-level API. Consumers seeking to attest the state of the
-// platform should use tpm.AttestPlatform() instead.
+// platform should use tpm.AttestPlatform() instead.  Not supported when
+// using CommandChannel.
 func (t *TPM) MeasurementLog() ([]byte, error) {
 	el, err := t.tpm.measurementLog()
 	if err != nil {

--- a/attest/tpm_other.go
+++ b/attest/tpm_other.go
@@ -62,6 +62,6 @@ func (t *platformTPM) pcrs(alg HashAlg) ([]PCR, error) {
 	return nil, errUnsupported
 }
 
-func (t *platformTPM) measurementLog() ([]byte, error) {
+func platformMeasurementLog() ([]byte, error) {
 	return nil, errUnsupported
 }

--- a/attest/tpm_selector.go
+++ b/attest/tpm_selector.go
@@ -1,0 +1,276 @@
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package attest
+
+import (
+	"crypto"
+	"crypto/rsa"
+	"errors"
+	"fmt"
+	"github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/tpmutil"
+	"io"
+)
+
+// selectorTPM interfaces with a platformTPM or a CommandChannel.
+type selectorTPM struct {
+	version TPMVersion
+	interf  TPMInterface
+
+	sysPath string
+	rwc     io.ReadWriteCloser
+	pTPM    *platformTPM
+}
+
+func openCommandChannel(v TPMVersion, rwc io.ReadWriteCloser) (*TPM, error) {
+	if v == TPMVersion12 {
+		return nil, errors.New("TPM1.2 is not supported when using CommandChannel")
+	}
+	return &TPM{tpm: &selectorTPM{
+		version: TPMVersion20,
+		interf:  TPMInterfaceCommandChannelManaged,
+		rwc:     rwc,
+	}}, nil
+}
+
+func (t *selectorTPM) tpmVersion() TPMVersion {
+	if t.pTPM != nil {
+		return t.pTPM.tpmVersion()
+	}
+
+	return t.version
+}
+
+func (t *selectorTPM) close() error {
+	if t.pTPM != nil {
+		return t.pTPM.close()
+	}
+
+	switch t.version {
+	case TPMVersion20:
+		return t.rwc.Close()
+	default:
+		return fmt.Errorf("unsupported TPM version: %x", t.version)
+	}
+}
+
+// Info returns information about the TPM.
+func (t *selectorTPM) info() (*TPMInfo, error) {
+	if t.pTPM != nil {
+		return t.pTPM.info()
+	}
+
+	tInfo := TPMInfo{
+		Version:   t.version,
+		Interface: t.interf,
+	}
+
+	var err error
+	switch t.version {
+	case TPMVersion20:
+		var t2Info tpm20Info
+		t2Info, err = readTPM2VendorAttributes(t.rwc)
+		tInfo.Manufacturer = t2Info.manufacturer
+		tInfo.VendorInfo = t2Info.vendor
+		tInfo.FirmwareVersionMajor = t2Info.fwMajor
+		tInfo.FirmwareVersionMinor = t2Info.fwMinor
+	default:
+		return nil, fmt.Errorf("unsupported TPM version: %x", t.version)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &tInfo, nil
+}
+
+// Return value: handle, whether we generated a new one, error
+func (t *selectorTPM) getPrimaryKeyHandle(pHnd tpmutil.Handle) (tpmutil.Handle, bool, error) {
+	_, _, _, err := tpm2.ReadPublic(t.rwc, pHnd)
+	if err == nil {
+		// Found the persistent handle, assume it's the key we want.
+		return pHnd, false, nil
+	}
+
+	var keyHnd tpmutil.Handle
+	switch pHnd {
+	case commonSrkEquivalentHandle:
+		keyHnd, _, err = tpm2.CreatePrimary(t.rwc, tpm2.HandleOwner, tpm2.PCRSelection{}, "", "", defaultSRKTemplate)
+	case commonEkEquivalentHandle:
+		keyHnd, _, err = tpm2.CreatePrimary(t.rwc, tpm2.HandleEndorsement, tpm2.PCRSelection{}, "", "", defaultEKTemplate)
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("CreatePrimary failed: %v", err)
+	}
+	defer tpm2.FlushContext(t.rwc, keyHnd)
+
+	err = tpm2.EvictControl(t.rwc, "", tpm2.HandleOwner, keyHnd, pHnd)
+	if err != nil {
+		return 0, false, fmt.Errorf("EvictControl failed: %v", err)
+	}
+
+	return pHnd, true, nil
+}
+
+func (t *selectorTPM) eks() ([]EK, error) {
+	if t.pTPM != nil {
+		return t.pTPM.eks()
+	}
+
+	switch t.version {
+	case TPMVersion20:
+		if cert, err := readEKCertFromNVRAM20(t.rwc); err == nil {
+			return []EK{
+				{Public: crypto.PublicKey(cert.PublicKey), Certificate: cert},
+			}, nil
+		}
+
+		// Attempt to create an EK.
+		ekHnd, _, err := tpm2.CreatePrimary(t.rwc, tpm2.HandleEndorsement, tpm2.PCRSelection{}, "", "", defaultEKTemplate)
+		if err != nil {
+			return nil, fmt.Errorf("EK CreatePrimary failed: %v", err)
+		}
+		defer tpm2.FlushContext(t.rwc, ekHnd)
+
+		pub, _, _, err := tpm2.ReadPublic(t.rwc, ekHnd)
+		if err != nil {
+			return nil, fmt.Errorf("EK ReadPublic failed: %v", err)
+		}
+		if pub.RSAParameters == nil {
+			return nil, errors.New("ECC EK not yet supported")
+		}
+		return []EK{
+			{
+				Public: &rsa.PublicKey{
+					E: int(pub.RSAParameters.Exponent()),
+					N: pub.RSAParameters.Modulus(),
+				},
+			},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported TPM version: %x", t.version)
+	}
+}
+
+func (t *selectorTPM) newAK(opts *AKConfig) (*AK, error) {
+	if t.pTPM != nil {
+		return t.pTPM.newAK(opts)
+	}
+
+	switch t.version {
+	case TPMVersion20:
+		// TODO(jsonp): Abstract choice of hierarchy & parent.
+		srk, _, err := t.getPrimaryKeyHandle(commonSrkEquivalentHandle)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get SRK handle: %v", err)
+		}
+
+		blob, pub, creationData, creationHash, tix, err := tpm2.CreateKey(t.rwc, srk, tpm2.PCRSelection{}, "", "", akTemplate)
+		if err != nil {
+			return nil, fmt.Errorf("CreateKeyEx() failed: %v", err)
+		}
+		keyHandle, _, err := tpm2.Load(t.rwc, srk, "", pub, blob)
+		if err != nil {
+			return nil, fmt.Errorf("Load() failed: %v", err)
+		}
+		// If any errors occur, free the AK's handle.
+		defer func() {
+			if err != nil {
+				tpm2.FlushContext(t.rwc, keyHandle)
+			}
+		}()
+
+		// We can only certify the creation immediately afterwards, so we cache the result.
+		attestation, sig, err := tpm2.CertifyCreation(t.rwc, "", keyHandle, keyHandle, nil, creationHash, tpm2.SigScheme{tpm2.AlgRSASSA, tpm2.AlgSHA256, 0}, &tix)
+		if err != nil {
+			return nil, fmt.Errorf("CertifyCreation failed: %v", err)
+		}
+		// Pack the raw structure into a TPMU_SIGNATURE.
+		signature, err := tpmutil.Pack(tpm2.AlgRSASSA, tpm2.AlgSHA256, tpmutil.U16Bytes(sig))
+		if err != nil {
+			return nil, fmt.Errorf("failed to pack TPMT_SIGNATURE: %v", err)
+		}
+		return &AK{ak: newKey20(keyHandle, blob, pub, creationData, attestation, signature)}, nil
+	default:
+		return nil, fmt.Errorf("unsupported TPM version: %x", t.version)
+	}
+}
+
+func (t *selectorTPM) loadAK(opaqueBlob []byte) (*AK, error) {
+	if t.pTPM != nil {
+		return t.pTPM.loadAK(opaqueBlob)
+	}
+
+	sKey, err := deserializeKey(opaqueBlob, t.version)
+	if err != nil {
+		return nil, fmt.Errorf("deserializeKey() failed: %v", err)
+	}
+	if sKey.Encoding != keyEncodingEncrypted {
+		return nil, fmt.Errorf("unsupported key encoding: %x", sKey.Encoding)
+	}
+
+	switch sKey.TPMVersion {
+	case TPMVersion20:
+		srk, _, err := t.getPrimaryKeyHandle(commonSrkEquivalentHandle)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get SRK handle: %v", err)
+		}
+		var hnd tpmutil.Handle
+		if hnd, _, err = tpm2.Load(t.rwc, srk, "", sKey.Public, sKey.Blob); err != nil {
+			return nil, fmt.Errorf("Load() failed: %v", err)
+		}
+		return &AK{ak: newKey20(hnd, sKey.Blob, sKey.Public, sKey.CreateData, sKey.CreateAttestation, sKey.CreateSignature)}, nil
+	default:
+		return nil, fmt.Errorf("cannot load AK with TPM version: %v", sKey.TPMVersion)
+	}
+}
+
+func (t *selectorTPM) pcrs(alg HashAlg) ([]PCR, error) {
+	if t.pTPM != nil {
+		return t.pTPM.pcrs(alg)
+	}
+
+	var PCRs map[uint32][]byte
+	var err error
+
+	switch t.version {
+	case TPMVersion20:
+		PCRs, err = readAllPCRs20(t.rwc, alg.goTPMAlg())
+		if err != nil {
+			return nil, fmt.Errorf("failed to read PCRs: %v", err)
+		}
+
+	default:
+		return nil, fmt.Errorf("unsupported TPM version: %x", t.version)
+	}
+
+	out := make([]PCR, len(PCRs))
+	for index, digest := range PCRs {
+		out[int(index)] = PCR{
+			Index:     int(index),
+			Digest:    digest,
+			DigestAlg: alg.cryptoHash(),
+		}
+	}
+
+	return out, nil
+}
+
+func (t *selectorTPM) measurementLog() ([]byte, error) {
+	if t.interf == TPMInterfaceCommandChannelManaged {
+		return nil, errors.New("MeasurementLog is not supported when using CommandChannel")
+	}
+	return platformMeasurementLog()
+}


### PR DESCRIPTION
Fixes #156 

Adds `CommandChannel io.ReadWriter` to `OpenConfig` in order to pass network device or simulator to TPM.  `CommandChannel` is currently only supported on TPM2.0 ~~on Linux.  TPM1.2 and TPM2.0 on Windows methods would require significant refactoring to support `io.ReadWriter`.~~

~~Changes Linux TPM2.0 command channel from `io.ReadWriteCloser` to `io.ReadWriter` in order to accommodate streams that do not support `Close()`.  Adds upcast check in `platformTPM.close` method for `io.ReadWriteCloser`.~~

~~Adds `+build linux,!gofuzz` to `attest_simulated_tpm20_test.go`, which is how it appears things work today since this test class instantiates the Linux `platformTPM`.~~