### PR TITLE
Refactor *platformTPM -> tpmBase interface

### DIFF
--- a/attest/attest.go
+++ b/attest/attest.go
@@ -85,10 +85,10 @@ const (
 )
 
 type ak interface {
-	close(*platformTPM) error
+	close(tpmBase) error
 	marshal() ([]byte, error)
-	activateCredential(tpm *platformTPM, in EncryptedCredential) ([]byte, error)
-	quote(t *platformTPM, nonce []byte, alg HashAlg) (*Quote, error)
+	activateCredential(tpm tpmBase, in EncryptedCredential) ([]byte, error)
+	quote(t tpmBase, nonce []byte, alg HashAlg) (*Quote, error)
 	attestationParameters() AttestationParameters
 }
 

--- a/attest/attest_simulated_tpm20_test.go
+++ b/attest/attest_simulated_tpm20_test.go
@@ -33,7 +33,7 @@ func setupSimulatedTPM(t *testing.T) (*simulator.Simulator, *TPM) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return tpm, &TPM{tpm: &platformTPM{
+	return tpm, &TPM{tpm: &linuxTPM{
 		version: TPMVersion20,
 		interf:  TPMInterfaceKernelManaged,
 		sysPath: "/dev/tpmrm0",
@@ -240,7 +240,7 @@ func TestSimTPM20Persistence(t *testing.T) {
 	sim, tpm := setupSimulatedTPM(t)
 	defer sim.Close()
 
-	ekHnd, _, err := tpm.tpm.getPrimaryKeyHandle(commonEkEquivalentHandle)
+	ekHnd, _, err := tpm.tpm.(*linuxTPM).getPrimaryKeyHandle(commonEkEquivalentHandle)
 	if err != nil {
 		t.Fatalf("getPrimaryKeyHandle() failed: %v", err)
 	}
@@ -248,7 +248,7 @@ func TestSimTPM20Persistence(t *testing.T) {
 		t.Fatalf("bad EK-equivalent handle: got 0x%x, wanted 0x%x", ekHnd, commonEkEquivalentHandle)
 	}
 
-	ekHnd, p, err := tpm.tpm.getPrimaryKeyHandle(commonEkEquivalentHandle)
+	ekHnd, p, err := tpm.tpm.(*linuxTPM).getPrimaryKeyHandle(commonEkEquivalentHandle)
 	if err != nil {
 		t.Fatalf("second getPrimaryKeyHandle() failed: %v", err)
 	}

--- a/attest/tpm.go
+++ b/attest/tpm.go
@@ -267,11 +267,24 @@ func readAllPCRs20(tpm io.ReadWriter, alg tpm2.Algorithm) (map[uint32][]byte, er
 	return out, nil
 }
 
+// tpmBase defines the implementation of a TPM invariant.
+type tpmBase interface {
+	close() error
+	tpmVersion() TPMVersion
+	eks() ([]EK, error)
+	info() (*TPMInfo, error)
+
+	loadAK(opaqueBlob []byte) (*AK, error)
+	newAK(opts *AKConfig) (*AK, error)
+	pcrs(alg HashAlg) ([]PCR, error)
+	measurementLog() ([]byte, error)
+}
+
 //TPM interfaces with a TPM device on the system.
 type TPM struct {
-	// tpm holds a platform specific implementation of TPM logic: Windows or Linux.
-	// see *_linux.go and *_windows.go files for definitions of these structs.
-	tpm *platformTPM
+	// tpm refers to a concrete implementation of TPM logic, based on the current
+	// platform and TPM version.
+	tpm tpmBase
 }
 
 // Close shuts down the connection to the TPM.

--- a/attest/tpm_other.go
+++ b/attest/tpm_other.go
@@ -22,46 +22,10 @@ import (
 
 var errUnsupported = errors.New("tpm operations not supported from given build parameters")
 
-type platformTPM struct {
-}
-
 func probeSystemTPMs() ([]probedTPM, error) {
 	return nil, errUnsupported
 }
 
 func openTPM(tpm probedTPM) (*TPM, error) {
-	return nil, errUnsupported
-}
-
-func (t *platformTPM) tpmVersion() TPMVersion {
-	return TPMVersionAgnostic
-}
-
-func (t *platformTPM) close() error {
-
-	return errUnsupported
-}
-
-func (t *platformTPM) info() (*TPMInfo, error) {
-	return nil, errUnsupported
-}
-
-func (t *platformTPM) loadAK(opaqueBlob []byte) (*AK, error) {
-	return nil, errUnsupported
-}
-
-func (t *platformTPM) eks() ([]EK, error) {
-	return nil, errUnsupported
-}
-
-func (t *platformTPM) newAK(opts *AKConfig) (*AK, error) {
-	return nil, errUnsupported
-}
-
-func (t *platformTPM) pcrs(alg HashAlg) ([]PCR, error) {
-	return nil, errUnsupported
-}
-
-func (t *platformTPM) measurementLog() ([]byte, error) {
 	return nil, errUnsupported
 }


### PR DESCRIPTION
Part 1/2 of the refactor to support injecting a wrapped TPM implementation.

This PR just moves from the existing struct pointer, where implementations where switched in using build tags, to structs implementing an interface. A future PR will:

1. Decompose `linuxTPM` into `linuxTPM12` and `wrappedTPM20`
2. Implement API surface to provided a TPM command channel instead of using the current platform
3. Move `wrappedTPM20` out of the linux build tag