### PR TITLE
Handle platform certificates that only provide a single property

### DIFF
--- a/attributecert/attributecert.go
+++ b/attributecert/attributecert.go
@@ -448,6 +448,13 @@ type PlatformConfigurationV2 struct {
 	PlatformPropertiesURI   URIReference            `asn1:"optional,tag:3"`
 }
 
+type PlatformConfigurationV2_workaround struct {
+	ComponentIdentifiers    []ComponentIdentifierV2 `asn1:"optional,tag:0"`
+	ComponentIdentifiersURI URIReference            `asn1:"optional,tag:1"`
+	PlatformProperty        Property                `asn1:"optional,tag:2"`
+	PlatformPropertiesURI   URIReference            `asn1:"optional,tag:3"`
+}
+
 type ComponentIdentifierV1 struct {
 	ComponentClass          []byte `asn1:"optional"`
 	ComponentManufacturer   string
@@ -580,7 +587,14 @@ func parseAttributeCertificate(in *attributeCertificate) (*AttributeCertificate,
 		case attribute.ID.Equal(oidTcgPlatformConfigurationV2):
 			var platformConfiguration PlatformConfigurationV2
 			if _, err := asn1.Unmarshal(attribute.RawValues[0].FullBytes, &platformConfiguration); err != nil {
-				return nil, err
+				var workaround PlatformConfigurationV2_workaround
+				if _, err := asn1.Unmarshal(attribute.RawValues[0].FullBytes, &workaround); err != nil {
+					return nil, err
+				}
+				platformConfiguration.ComponentIdentifiers = workaround.ComponentIdentifiers
+				platformConfiguration.ComponentIdentifiersURI = workaround.ComponentIdentifiersURI
+				platformConfiguration.PlatformProperties = append(platformConfiguration.PlatformProperties, workaround.PlatformProperty)
+				platformConfiguration.PlatformPropertiesURI = workaround.PlatformPropertiesURI
 			}
 			for _, component := range platformConfiguration.ComponentIdentifiers {
 				t := Component{

--- a/attributecert/attributecert.go
+++ b/attributecert/attributecert.go
@@ -448,7 +448,7 @@ type PlatformConfigurationV2 struct {
 	PlatformPropertiesURI   URIReference            `asn1:"optional,tag:3"`
 }
 
-type PlatformConfigurationV2_workaround struct {
+type PlatformConfigurationV2Workaround struct {
 	ComponentIdentifiers    []ComponentIdentifierV2 `asn1:"optional,tag:0"`
 	ComponentIdentifiersURI URIReference            `asn1:"optional,tag:1"`
 	PlatformProperty        Property                `asn1:"optional,tag:2"`
@@ -587,7 +587,7 @@ func parseAttributeCertificate(in *attributeCertificate) (*AttributeCertificate,
 		case attribute.ID.Equal(oidTcgPlatformConfigurationV2):
 			var platformConfiguration PlatformConfigurationV2
 			if _, err := asn1.Unmarshal(attribute.RawValues[0].FullBytes, &platformConfiguration); err != nil {
-				var workaround PlatformConfigurationV2_workaround
+				var workaround PlatformConfigurationV2Workaround
 				if _, err := asn1.Unmarshal(attribute.RawValues[0].FullBytes, &workaround); err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
The spec states that the PlatformProperties field of the
PlatformConfiguration attribute should be a sequence of key value pairs.
However, it seems that if there's only a single property present, it's
sometimes being stored as a bare key value pair rather than a sequence
with a single entry. Work around that.