### PR TITLE
Fix Go Vet string conversion warnings

### DIFF
--- a/attest/tpm.go
+++ b/attest/tpm.go
@@ -121,7 +121,9 @@ func readTPM2VendorAttributes(tpm io.ReadWriter) (tpm20Info, error) {
 			return tpm20Info{}, fmt.Errorf("got capability of type %T, want tpm2.TaggedProperty", caps[0])
 		}
 		// Reconstruct the 4 ASCII octets from the uint32 value.
-		vendorInfo += string(subset.Value&0xFF000000) + string(subset.Value&0xFF0000) + string(subset.Value&0xFF00) + string(subset.Value&0xFF)
+		b := make([]byte, 4)
+		binary.BigEndian.PutUint32(b, subset.Value)
+		vendorInfo += string(b)
 	}
 
 	caps, _, err := tpm2.GetCapability(tpm, tpm2.CapabilityTPMProperties, 1, tpmPtManufacturer)

--- a/attest/win_events.go
+++ b/attest/win_events.go
@@ -636,7 +636,7 @@ func (w *WinEvents) parseUTF16(header microsoftEventHeader, r io.Reader) (string
 	if err := binary.Read(r, binary.LittleEndian, &data); err != nil {
 		return "", err
 	}
-	return strings.TrimSuffix(string(utf16.Decode(data)), string(0x00)), nil
+	return strings.TrimSuffix(string(utf16.Decode(data)), "\x00"), nil
 }
 
 func (w *WinEvents) readELAMAggregation(rdr *bytes.Reader, header microsoftEventHeader) error {


### PR DESCRIPTION
https://golang.org/doc/go1.15#vet