### PR TITLE
Export InvalidPCRs field in ReplayError

### DIFF
--- a/attest/eventlog.go
+++ b/attest/eventlog.go
@@ -38,11 +38,11 @@ import (
 // a particular PCR.
 type ReplayError struct {
 	Events      []Event
-	invalidPCRs []int
+	InvalidPCRs []int
 }
 
 func (e ReplayError) affected(pcr int) bool {
-	for _, p := range e.invalidPCRs {
+	for _, p := range e.InvalidPCRs {
 		if p == pcr {
 			return true
 		}
@@ -52,7 +52,7 @@ func (e ReplayError) affected(pcr int) bool {
 
 // Error returns a human-friendly description of replay failures.
 func (e ReplayError) Error() string {
-	return fmt.Sprintf("event log failed to verify: the following registers failed to replay: %v", e.invalidPCRs)
+	return fmt.Sprintf("event log failed to verify: the following registers failed to replay: %v", e.InvalidPCRs)
 }
 
 // TPM algorithms. See the TPM 2.0 specification section 6.3.
@@ -393,7 +393,7 @@ pcrLoop:
 		}
 		return nil, ReplayError{
 			Events:      events,
-			invalidPCRs: invalidReplays,
+			InvalidPCRs: invalidReplays,
 		}
 	}
 

--- a/attest/eventlog.go
+++ b/attest/eventlog.go
@@ -38,6 +38,7 @@ import (
 // a particular PCR.
 type ReplayError struct {
 	Events      []Event
+	// InvalidPCRs reports the set of PCRs where the event log replay failed.
 	InvalidPCRs []int
 }
 


### PR DESCRIPTION
## Proposed Changes 
In order to retrieve the Invalid PCRs which couldn't be replayed against the Event log, we need this field to be exported as this gives the exact and true information. Replay error events will give all the events, but doesn't give the exact PCR index which doesn't get replayed. 

Following is the test to extend PCR 7 and verify the PCRs 7,8,9 against the Event log. Output:
```
event log failed to verify: the following registers failed to replay: [7]
ReplayError Events:=[107]
Replay Error Events PCR indexes=[0 7 2 3 6 9 8 1 4 5]
```