### PR TITLE
Deepikarajani24 patch 1

### DIFF
--- a/attest/pcp_windows.go
+++ b/attest/pcp_windows.go
@@ -58,8 +58,8 @@ var (
 	crypt32CertEnumCertificatesInStore = crypt32.MustFindProc("CertEnumCertificatesInStore")
 	crypt32CertCloseStore              = crypt32.MustFindProc("CertCloseStore")
 
-	tbs              = windows.MustLoadDLL("Tbs.dll")
-	tbsGetDeviceInfo = tbs.MustFindProc("Tbsi_GetDeviceInfo")
+	tbs              *windows.DLL
+	tbsGetDeviceInfo *windows.Proc
 )
 
 // Error codes.

--- a/attest/tpm_windows.go
+++ b/attest/tpm_windows.go
@@ -42,6 +42,10 @@ type windowsTPM struct {
 func (*windowsTPM) isTPMBase() {}
 
 func probeSystemTPMs() ([]probedTPM, error) {
+	// Initialize Tbs.dll here so that it's linked only when TPM support is required.
+	tbs = windows.MustLoadDLL("Tbs.dll")
+	tbsGetDeviceInfo = tbs.MustFindProc("Tbsi_GetDeviceInfo")
+	
 	// Windows systems appear to only support a single abstracted TPM.
 	// If we fail to initialize the Platform Crypto Provider, we assume
 	// a TPM is not present.

--- a/attest/tpm_windows.go
+++ b/attest/tpm_windows.go
@@ -45,8 +45,8 @@ func probeSystemTPMs() ([]probedTPM, error) {
 	// Initialize Tbs.dll here so that it's linked only when TPM support is required.
 	if tbs == nil {
 		tbs = windows.MustLoadDLL("Tbs.dll")
+		tbsGetDeviceInfo = tbs.MustFindProc("Tbsi_GetDeviceInfo")
 	}
-	tbsGetDeviceInfo = tbs.MustFindProc("Tbsi_GetDeviceInfo")
 	
 	// Windows systems appear to only support a single abstracted TPM.
 	// If we fail to initialize the Platform Crypto Provider, we assume

--- a/attest/tpm_windows.go
+++ b/attest/tpm_windows.go
@@ -43,7 +43,9 @@ func (*windowsTPM) isTPMBase() {}
 
 func probeSystemTPMs() ([]probedTPM, error) {
 	// Initialize Tbs.dll here so that it's linked only when TPM support is required.
-	tbs = windows.MustLoadDLL("Tbs.dll")
+	if tbs == nil {
+		tbs = windows.MustLoadDLL("Tbs.dll")
+	}
 	tbsGetDeviceInfo = tbs.MustFindProc("Tbsi_GetDeviceInfo")
 	
 	// Windows systems appear to only support a single abstracted TPM.


### PR DESCRIPTION
this PR removed the dependency on tbs.dll when TPM support is not required for windows which is the case for any independent verifier application which doesn't need to have tbs.dll available to do the verification of an attest machine