### PR TITLE
attest: add bounds checks for slice indexes

### DIFF
--- a/attest/activation.go
+++ b/attest/activation.go
@@ -233,6 +233,12 @@ func (p *ActivationParameters) generateChallengeTPM20(secret []byte) (*Encrypted
 	if err != nil {
 		return nil, fmt.Errorf("DecodeAttestationData() failed: %v", err)
 	}
+	if att.AttestedCreationInfo == nil {
+		return nil, fmt.Errorf("attestation was not for a creation event")
+	}
+	if att.AttestedCreationInfo.Name.Digest == nil {
+		return nil, fmt.Errorf("attestation creation info name has no digest")
+	}
 	cred, encSecret, err := credactivation.Generate(att.AttestedCreationInfo.Name.Digest, p.EK, symBlockSize, secret)
 	if err != nil {
 		return nil, fmt.Errorf("credactivation.Generate() failed: %v", err)

--- a/attest/secureboot.go
+++ b/attest/secureboot.go
@@ -164,7 +164,7 @@ func ParseSecurebootState(events []Event) (*SecurebootState, error) {
 					// https://github.com/rhboot/shim/commit/8a27a4809a6a2b40fb6a4049071bf96d6ad71b50
 					// have an erroneous additional byte in the event, which breaks digest
 					// verification. If verification failed, we try removing the last byte.
-					if digestVerify != nil {
+					if digestVerify != nil && len(e.Data) > 0 {
 						digestVerify = e.digestEquals(e.Data[:len(e.Data)-1])
 					}
 				} else {

--- a/attest/wrapped_tpm20.go
+++ b/attest/wrapped_tpm20.go
@@ -246,6 +246,15 @@ func (k *wrappedKey20) activateCredential(tb tpmBase, in EncryptedCredential) ([
 		return nil, fmt.Errorf("expected *wrappedTPM20, got %T", tb)
 	}
 
+	if len(in.Credential) < 2 {
+		return nil, fmt.Errorf("malformed credential blob")
+	}
+	credential := in.Credential[2:]
+	if len(in.Secret) < 2 {
+		return nil, fmt.Errorf("malformed encrypted secret")
+	}
+	secret := in.Secret[2:]
+
 	ekHnd, _, err := t.getPrimaryKeyHandle(commonEkEquivalentHandle)
 	if err != nil {
 		return nil, err
@@ -272,7 +281,7 @@ func (k *wrappedKey20) activateCredential(tb tpmBase, in EncryptedCredential) ([
 	return tpm2.ActivateCredentialUsingAuth(t.rwc, []tpm2.AuthCommand{
 		{Session: tpm2.HandlePasswordSession, Attributes: tpm2.AttrContinueSession},
 		{Session: sessHandle, Attributes: tpm2.AttrContinueSession},
-	}, k.hnd, ekHnd, in.Credential[2:], in.Secret[2:])
+	}, k.hnd, ekHnd, credential, secret)
 }
 
 func (k *wrappedKey20) quote(tb tpmBase, nonce []byte, alg HashAlg) (*Quote, error) {


### PR DESCRIPTION
Found manually looking through the code. The activate credential could
crash the client, while the secureboot may be able to crash the server.