### PR TITLE
Minor fixes and additions

### DIFF
--- a/attest/application_key.go
+++ b/attest/application_key.go
@@ -103,7 +103,7 @@ func (k *Key) CertificationParameters() CertificationParameters {
 	return k.key.certificationParameters()
 }
 
-// PrivPubBlobs returns private and public blobs to be used by tpm2.Load().
-func (k *Key) PrivPubBlobs() ([]byte, []byte, error) {
+// PubPrivBlobs returns private and public blobs to be used by tpm2.Load().
+func (k *Key) PubPrivBlobs() ([]byte, []byte, error) {
 	return k.key.blobs()
 }

--- a/attest/application_key.go
+++ b/attest/application_key.go
@@ -103,7 +103,7 @@ func (k *Key) CertificationParameters() CertificationParameters {
 	return k.key.certificationParameters()
 }
 
-// PubPrivBlobs returns private and public blobs to be used by tpm2.Load().
-func (k *Key) PubPrivBlobs() ([]byte, []byte, error) {
+// Blobs returns private and public blobs to be used by tpm2.Load().
+func (k *Key) Blobs() ([]byte, []byte, error) {
 	return k.key.blobs()
 }

--- a/attest/application_key.go
+++ b/attest/application_key.go
@@ -103,7 +103,7 @@ func (k *Key) CertificationParameters() CertificationParameters {
 	return k.key.certificationParameters()
 }
 
-// Blobs returns private and public blobs to be used by tpm2.Load().
-func (k *Key) Blobs() ([]byte, []byte, error) {
+// Blobs returns public and private blobs to be used by tpm2.Load().
+func (k *Key) Blobs() (pub, priv []byte, err error) {
 	return k.key.blobs()
 }

--- a/attest/application_key.go
+++ b/attest/application_key.go
@@ -28,6 +28,7 @@ type key interface {
 	certificationParameters() CertificationParameters
 	sign(tpmBase, []byte) ([]byte, error)
 	decrypt(tpmBase, []byte) ([]byte, error)
+	blobs() ([]byte, []byte, error)
 }
 
 // Key represents a key which can be used for signing and decrypting
@@ -100,4 +101,9 @@ func (k *Key) Marshal() ([]byte, error) {
 // verify key certification.
 func (k *Key) CertificationParameters() CertificationParameters {
 	return k.key.certificationParameters()
+}
+
+// PrivPubBlobs returns private and public blobs to be used by tpm2.Load().
+func (k *Key) PrivPubBlobs() ([]byte, []byte, error) {
+	return k.key.blobs()
 }

--- a/attest/attest.go
+++ b/attest/attest.go
@@ -24,7 +24,6 @@ import (
 	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/go-tpm/tpm"
 	"github.com/google/go-tpm/tpm2"
-	"github.com/google/go-tpm/tpmutil"
 )
 
 // TPMVersion is used to configure a preference in
@@ -104,7 +103,6 @@ type ak interface {
 	activateCredential(tpm tpmBase, in EncryptedCredential) ([]byte, error)
 	quote(t tpmBase, nonce []byte, alg HashAlg) (*Quote, error)
 	attestationParameters() AttestationParameters
-	handle() (tpmutil.Handle, error)
 }
 
 // AK represents a key which can be used for attestation.

--- a/attest/key_linux.go
+++ b/attest/key_linux.go
@@ -19,7 +19,6 @@ package attest
 import (
 	"fmt"
 
-	"github.com/google/go-tpm/tpmutil"
 	"github.com/google/go-tspi/attestation"
 )
 
@@ -91,8 +90,4 @@ func (k *trousersKey12) attestationParameters() AttestationParameters {
 		Public:                  k.public,
 		UseTCSDActivationFormat: true,
 	}
-}
-
-func (k *trousersKey12) handle() (tpmutil.Handle, error) {
-	return 0, fmt.Errorf("not implemented")
 }

--- a/attest/key_windows.go
+++ b/attest/key_windows.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	tpm1 "github.com/google/go-tpm/tpm"
-	"github.com/google/go-tpm/tpmutil"
 )
 
 // windowsKey12 represents a Windows-managed key on a TPM1.2 TPM.
@@ -112,10 +111,6 @@ func (k *windowsKey12) attestationParameters() AttestationParameters {
 	}
 }
 
-func (k *windowsKey12) handle() (tpmutil.Handle, error) {
-	return 0, fmt.Errorf("not implemented")
-}
-
 // windowsKey20 represents a key bound to a TPM 2.0.
 type windowsKey20 struct {
 	hnd uintptr
@@ -188,8 +183,4 @@ func (k *windowsKey20) attestationParameters() AttestationParameters {
 		CreateAttestation: k.createAttestation,
 		CreateSignature:   k.createSignature,
 	}
-}
-
-func (k *windowsKey20) handle() (tpmutil.Handle, error) {
-	return 0, fmt.Errorf("not implemented")
 }

--- a/attest/wrapped_tpm20.go
+++ b/attest/wrapped_tpm20.go
@@ -422,5 +422,5 @@ func (k *wrappedKey20) decrypt(tb tpmBase, ctxt []byte) ([]byte, error) {
 }
 
 func (k *wrappedKey20) blobs() ([]byte, []byte, error) {
-	return k.blob, k.public, nil
+	return k.public, k.blob, nil
 }

--- a/attest/wrapped_tpm20.go
+++ b/attest/wrapped_tpm20.go
@@ -420,3 +420,7 @@ func (k *wrappedKey20) sign(tb tpmBase, digest []byte) ([]byte, error) {
 func (k *wrappedKey20) decrypt(tb tpmBase, ctxt []byte) ([]byte, error) {
 	return nil, fmt.Errorf("not implemented")
 }
+
+func (k *wrappedKey20) blobs() ([]byte, []byte, error) {
+	return k.blob, k.public, nil
+}


### PR DESCRIPTION
- replace ReadPublic() by DecodePublic() when creating and loading keys: the current implementation calls ReadPublic() even if public data is already accessible
- drop handle() from the ak interface: it is unnecessary
- add PrivPubBlobs() to attest.Key: to allow `attest`-agnostic  key marshaling