### PR TITLE
win_events: Determine if the WBCL was for a cold boot

### DIFF
--- a/attest/win_events_test.go
+++ b/attest/win_events_test.go
@@ -25,6 +25,7 @@ import (
 
 func TestParseWinEvents(t *testing.T) {
 	want := &WinEvents{
+		ColdBoot:             true,
 		BootCount:            4,
 		DEPEnabled:           true,
 		CodeIntegrityEnabled: true,


### PR DESCRIPTION
as opposed to a resume from hibernation.