### PR TITLE
Parse TCG_PCClientPCREvent structures with an eventSize of 0

### DIFF
--- a/attest/eventlog.go
+++ b/attest/eventlog.go
@@ -657,9 +657,6 @@ func parseRawEvent(r *bytes.Buffer, specID *specIDEvent) (event rawEvent, err er
 	if err = binary.Read(r, binary.LittleEndian, &h); err != nil {
 		return event, fmt.Errorf("header deserialization error: %w", err)
 	}
-	if h.EventSize == 0 {
-		return event, errors.New("event data size is 0")
-	}
 	if h.EventSize > uint32(r.Len()) {
 		return event, &eventSizeErr{h.EventSize, r.Len()}
 	}

--- a/attest/eventlog_test.go
+++ b/attest/eventlog_test.go
@@ -15,6 +15,7 @@
 package attest
 
 import (
+	"bytes"
 	"encoding/json"
 	"io/ioutil"
 	"testing"
@@ -146,6 +147,29 @@ func TestParseEventLogEventSizeTooLarge(t *testing.T) {
 	_, err := ParseEventLog(data)
 	if err == nil {
 		t.Fatalf("expected parsing invalid event log to fail")
+	}
+}
+
+func TestParseEventLogEventSizeZero(t *testing.T) {
+	data := []byte{
+		// PCR index
+		0x4, 0x0, 0x0, 0x0,
+
+		// type
+		0xd, 0x0, 0x0, 0x0,
+
+		// Digest
+		0x94, 0x2d, 0xb7, 0x4a, 0xa7, 0x37, 0x5b, 0x23, 0xea, 0x23,
+		0x58, 0xeb, 0x3b, 0x31, 0x59, 0x88, 0x60, 0xf6, 0x90, 0x59,
+
+		// Event size (0 B)
+		0x0, 0x0, 0x0, 0x0,
+
+		// no "event data"
+	}
+
+	if _, err := parseRawEvent(bytes.NewBuffer(data), nil); err != nil {
+		t.Fatalf("parsing event log: %v", err)
 	}
 }
 


### PR DESCRIPTION
Some TPM 1.2 devices emit `EV_IPL` events with an `eventSize` of 0 and an empty `event` field. The specification would appear to suggest that only the digest itself is relevant for this event type and the information stored in the `event` field is only informational.

From [TCG PC Client Specific Implementation Specification for Conventional BIOS](https://trustedcomputinggroup.org/wp-content/uploads/TCG_PCClientImplementation_1-21_1_00.pdf):
```
Used in PCR[4] and may be used in OS PCRs (e.g.,
8-15).
The digest field contains the SHA-1 hash of the IPL
Code. The event field SHOULD NOT contain the
actual IPL Code but MAY contain informative
information about the IPL Code. Note: The digest
may not cover the entire area hosting the IPL Image,
but only the portion that contains the IPL Code. For
example, if the IPL Image is a disk drive MBR, this
MUST NOT include the portion of the MBR that
contains the disk geometry.
For MBR code, the event data SHOULD be “MBR”.
For floppy disks, the event data SHOULD be
“FLOPPY DISK”.
For BCV devices, the event data SHOULD be “BCV
IPL”.
For BEV devices, the event data SHOULD be “BEV
IPL”.
For a PARTIES partition, the event data SHOULD be
“PARTIES IPL”.
For El Torito complaint devices, the event data
SHOULD be “EL TORITO IPL”.
For other devices, the event data SHOULD be “IPL”.
See Section 3.3.3.5.```