### PR TITLE
Validate RSA-PSS salt argument.

### DIFF
--- a/attest/application_key.go
+++ b/attest/application_key.go
@@ -62,8 +62,7 @@ type Algorithm string
 // Algorithm types supported.
 const (
 	ECDSA Algorithm = "ECDSA"
-	// TODO(szp): RSA is not supported yet
-	RSA Algorithm = "RSA"
+	RSA   Algorithm = "RSA"
 )
 
 // KeyConfig encapsulates parameters for minting keys.

--- a/attest/application_key_test.go
+++ b/attest/application_key_test.go
@@ -178,14 +178,6 @@ func TestTPM20KeySign(t *testing.T) {
 	testKeySign(t, tpm)
 }
 
-type simpleOpts struct {
-	Hash crypto.Hash
-}
-
-func (o *simpleOpts) HashFunc() crypto.Hash {
-	return o.Hash
-}
-
 func testKeySign(t *testing.T, tpm *TPM) {
 	ak, err := tpm.NewAK(nil)
 	if err != nil {
@@ -237,10 +229,8 @@ func testKeySign(t *testing.T, tpm *TPM) {
 				Algorithm: RSA,
 				Size:      2048,
 			},
-			signOpts: &simpleOpts{
-				Hash: crypto.SHA256,
-			},
-			digest: []byte("12345678901234567890123456789012"),
+			signOpts: crypto.SHA256,
+			digest:   []byte("12345678901234567890123456789012"),
 		},
 		{
 			name: "RSA2048-PKCS1v15-SHA384",
@@ -248,10 +238,8 @@ func testKeySign(t *testing.T, tpm *TPM) {
 				Algorithm: RSA,
 				Size:      2048,
 			},
-			signOpts: &simpleOpts{
-				Hash: crypto.SHA384,
-			},
-			digest: []byte("123456789012345678901234567890121234567890123456"),
+			signOpts: crypto.SHA384,
+			digest:   []byte("123456789012345678901234567890121234567890123456"),
 		},
 		{
 			name: "RSA2048-PKCS1v15-SHA512",
@@ -259,10 +247,8 @@ func testKeySign(t *testing.T, tpm *TPM) {
 				Algorithm: RSA,
 				Size:      2048,
 			},
-			signOpts: &simpleOpts{
-				Hash: crypto.SHA512,
-			},
-			digest: []byte("1234567890123456789012345678901212345678901234567890123456789012"),
+			signOpts: crypto.SHA512,
+			digest:   []byte("1234567890123456789012345678901212345678901234567890123456789012"),
 		},
 		{
 			name: "RSA2048-PSS-SHA256",
@@ -296,6 +282,42 @@ func testKeySign(t *testing.T, tpm *TPM) {
 			},
 			signOpts: &rsa.PSSOptions{
 				SaltLength: rsa.PSSSaltLengthAuto,
+				Hash:       crypto.SHA512,
+			},
+			digest: []byte("1234567890123456789012345678901212345678901234567890123456789012"),
+		},
+		{
+			name: "RSA2048-PSS-SHA256, explicit salt len",
+			keyOpts: &KeyConfig{
+				Algorithm: RSA,
+				Size:      2048,
+			},
+			signOpts: &rsa.PSSOptions{
+				SaltLength: 32,
+				Hash:       crypto.SHA256,
+			},
+			digest: []byte("12345678901234567890123456789012"),
+		},
+		{
+			name: "RSA2048-PSS-SHA384, explicit salt len",
+			keyOpts: &KeyConfig{
+				Algorithm: RSA,
+				Size:      2048,
+			},
+			signOpts: &rsa.PSSOptions{
+				SaltLength: 48,
+				Hash:       crypto.SHA384,
+			},
+			digest: []byte("123456789012345678901234567890121234567890123456"),
+		},
+		{
+			name: "RSA2048-PSS-SHA512, explicit salt len",
+			keyOpts: &KeyConfig{
+				Algorithm: RSA,
+				Size:      2048,
+			},
+			signOpts: &rsa.PSSOptions{
+				SaltLength: 64,
 				Hash:       crypto.SHA512,
 			},
 			digest: []byte("1234567890123456789012345678901212345678901234567890123456789012"),

--- a/attest/wrapped_tpm20.go
+++ b/attest/wrapped_tpm20.go
@@ -512,7 +512,11 @@ func signRSA(rw io.ReadWriter, key tpmutil.Handle, digest []byte, opts crypto.Si
 		Alg:  tpm2.AlgRSASSA,
 		Hash: h,
 	}
-	if _, ok := opts.(*rsa.PSSOptions); ok {
+
+	if pss, ok := opts.(*rsa.PSSOptions); ok {
+		if pss.SaltLength != rsa.PSSSaltLengthAuto && pss.SaltLength != len(digest) {
+			return nil, fmt.Errorf("PSS salt length %d is incorrect, expected rsa.PSSSaltLengthAuto or %d", pss.SaltLength, len(digest))
+		}
 		scheme.Alg = tpm2.AlgRSAPSS
 	}
 


### PR DESCRIPTION
TPM's RSA-PSS signing doesn't take a salt argument, so let's make sure that the options given in Sign() are correct for most (all?) sensible cases.