### PR TITLE
Add a build tag to turn off TPM12 support and avoid tspi dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,12 @@ Please note that this is not an official Google product.
 
 The go-attestation package is installable using go get: `go get github.com/google/go-attestation/attest`
 
-Linux users must install `libtspi` and its headers. This can be installed on debian-based systems using: `sudo apt-get install libtspi-dev`.
+Linux users must install `libtspi` and its headers if they need TPM 1.2 support. This can be installed on debian-based systems using: `sudo apt-get install libtspi-dev`.
+
+In case Linux users need only TPM 2.0 support, they can:
+* still install `libtspi`
+* or turn off cgo completely, e.g., `CGO_ENABLED=0 go build`
+* or use `notspi` build tag if cgo is needed for some reasons, e.g., `go build --tags=notspi`
 
 ## Example: device identity
 

--- a/attest/key_linux.go
+++ b/attest/key_linux.go
@@ -12,7 +12,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-// +build linux,!gofuzz,cgo
+// +build linux,!gofuzz,cgo,!notspi
 
 package attest
 

--- a/attest/tpm12_linux.go
+++ b/attest/tpm12_linux.go
@@ -12,7 +12,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-// +build linux,!gofuzz,cgo
+// +build linux,!gofuzz,cgo,!notspi
 
 package attest
 


### PR DESCRIPTION
The PR provides the ability to turn off TPM12 support to avoid the installation of libtspi-dev (#202).

Right now `go test` fails if you have no libtspi, and `CGO_ENABLED=0 go test` fails too because tests require _setupSimulatedTPM_. _setupSimulatedTPM_ is defined in _attest/attest_simulated_tpm20_test.go_ which needs cgo.

After the PR, it can pass with `go test -tags notspi` (the warning is still there).