### PR TITLE
Handle EFI_ACTION events signalling DMA protection is disabled.

### DIFF
--- a/attest/pcp_windows.go
+++ b/attest/pcp_windows.go
@@ -26,9 +26,9 @@ import (
 
 	"github.com/google/certificate-transparency-go/x509"
 
-	"golang.org/x/sys/windows"
-	tpmtbs "github.com/google/go-tpm/tpmutil/tbs"
 	"github.com/google/go-tpm/tpmutil"
+	tpmtbs "github.com/google/go-tpm/tpmutil/tbs"
+	"golang.org/x/sys/windows"
 )
 
 const (

--- a/attest/tpm_windows.go
+++ b/attest/tpm_windows.go
@@ -28,9 +28,9 @@ import (
 	"io"
 	"math/big"
 
-	"golang.org/x/sys/windows"
 	tpm1 "github.com/google/go-tpm/tpm"
 	tpmtbs "github.com/google/go-tpm/tpmutil/tbs"
+	"golang.org/x/sys/windows"
 )
 
 var wellKnownAuth [20]byte


### PR DESCRIPTION
Starting to see some use of `ParseSecurebootState()` fail in production due to `event 15: unexpected EFI action event`.

This PR adds support for detecting and verifying that event, so such event logs can be supported as normal.