### PR TITLE
Invert 'notspi' build tag to 'tspi'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,24 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
       uses: actions/checkout@v2
+    - name: Test
+      run: go test ./...
+  test-linux-tpm12:
+    strategy:
+      matrix:
+        go-version: [1.16.x, 1.17.x]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
     - name: Install libtspi
       run: sudo apt-get install -y libtspi-dev
     - name: Test
-      run: go test ./...
+      run: go test -tags tspi ./...
   test-macos:
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ testing is not covered by CI.
 
 The go-attestation package is installable using go get: `go get github.com/google/go-attestation/attest`
 
-Linux users must install `libtspi` and its headers if they need TPM 1.2 support. This can be installed on debian-based systems using: `sudo apt-get install libtspi-dev`.
+### TPM1.2
+By default, go-attestation does not build in TPM1.2 support on Linux.
+Linux users must install [`libtspi`](http://trousers.sourceforge.net/) and its headers if they need TPM 1.2 support. This can be installed on debian-based systems using: `sudo apt-get install libtspi-dev`.
+Then, build go-attestation with the `tspi` [build tag](https://pkg.go.dev/go/build#hdr-Build_Constraints) `go build --tags=tspi`.
 
-In case Linux users need only TPM 2.0 support, they can:
-* still install `libtspi`
-* or turn off cgo completely, e.g., `CGO_ENABLED=0 go build`
-* or use `notspi` build tag if cgo is needed for some reasons, e.g., `go build --tags=notspi`
+Windows users can use go-attestation with TPM1.2 by default.
 
 ## Example: device identity
 

--- a/attest/key_linux.go
+++ b/attest/key_linux.go
@@ -12,7 +12,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-// +build linux,!gofuzz,cgo,!notspi
+// +build linux,!gofuzz,cgo,tspi
 
 package attest
 

--- a/attest/tpm12_linux.go
+++ b/attest/tpm12_linux.go
@@ -12,7 +12,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-// +build linux,!gofuzz,cgo,!notspi
+// +build linux,!gofuzz,cgo,tspi
 
 package attest
 


### PR DESCRIPTION
Discussed with @ericchiang and @twitchy-jsonp: we can remove go-attestation dependent packages' need to include libtspi without changing their build method, like the notspi tag (#232) requires.

This change allows users to specify TPM1.2 support rather than remove it. go-attestation will build without needing Trousers/TSPI support. The flip-side of this is that TPM1.2 does not just work; TPM1.2 users need to include the `tspi` build tag.

## Tested
```
$ sudo apt remove libtspi-dev
$ go test ./... 
# success

$ go test --tags=tspi ./...
# github.com/google/go-tspi/tspi
../../go/pkg/mod/github.com/google/go-tspi@v0.3.0/tspi/context.go:17:11: fatal error: 'trousers/tss.h' file not found
 #include <trousers/tss.h>
          ^~~~~~~~~~~~~~~~
1 error generated.
FAIL    github.com/google/go-attestation/attest [build failed]
FAIL    github.com/google/go-attestation/attest/attest-tool/internal/eventlog [build failed]
ok      github.com/google/go-attestation/attest/internal        (cached)
ok      github.com/google/go-attestation/attributecert  (cached)


$ sudo apt-get install libtspi-dev
$ go test --tags=tspi ./...
# success
```