### PR TITLE
.github: add initial github action for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,52 @@
+on: [push, pull_request]
+name: Test
+jobs:
+  test-linux:
+    strategy:
+      matrix:
+        go-version: [1.16.x, 1.17.x]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Install libtspi
+      run: sudo apt-get install -y libtspi-dev
+    - name: Test
+      run: go test ./...
+  test-macos:
+    strategy:
+      matrix:
+        go-version: [1.16.x, 1.17.x]
+    runs-on: macos-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+      # See https://github.com/google/go-tpm-tools#macos-dev
+    - name: Install openssl
+      run: brew install openssl
+    - name: Link openssl
+      run: sudo ln -s $(brew --prefix openssl)/include/openssl /usr/local/include
+    - name: Test
+      run: C_INCLUDE_PATH="$(brew --prefix openssl)/include" LIBRARY_PATH="$(brew --prefix openssl)/lib" go build ./...
+  test-windows:
+    strategy:
+      matrix:
+        go-version: [1.16.x, 1.17.x]
+    runs-on: windows-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Test
+      run: go build ./...

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ API changes at any time.
 
 Please note that this is not an official Google product.
 
+TPM 1.2 support is best effort, meaning we will accept fixes for TPM 1.2, but
+testing is not covered by CI.
+
 ## Installation
 
 The go-attestation package is installable using go get: `go get github.com/google/go-attestation/attest`

--- a/attest/attest_simulated_tpm20_test.go
+++ b/attest/attest_simulated_tpm20_test.go
@@ -12,10 +12,12 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+// +build linux
 // +build !localtest !tpm12
 // +build cgo
 
 // NOTE: simulator requires cgo, hence the build tag.
+// NOTE: currently requires linuxCmdChannel, which is only defined on Linux.
 
 package attest
 

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+
+1>&2 echo "-----
+WARNING: The TPM 1.2 simulator no longer builds with newer versions of openssl.
+These scripts are kept for posterity, but likely won't build on new OS
+versions.
+----"
+
+export PROJECT_ROOT="$( pwd )"
+TMPDIR="$( mktemp -d )"
+SIM_DIR="${TMPDIR}/tpm12_sim"
+
+TEST_ROOT="${TMPDIR}/tests_base"
+
+mkdir -pv "${SIM_DIR}"
+./ci/setup_tpm12_simulator.sh "${SIM_DIR}"
+./ci/setup_tests_fs.sh "${TEST_ROOT}"
+
+go test -v ./... -- --testTPM12
+
+./ci/shutdown_tpm12_simulator.sh "${SIM_DIR}"


### PR DESCRIPTION
Goal is to switch current builder run internally by Google over to
GitHub Actions.