### PR TITLE
attest: fix test build for MacOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Link openssl
       run: sudo ln -s $(brew --prefix openssl)/include/openssl /usr/local/include
     - name: Test
-      run: C_INCLUDE_PATH="$(brew --prefix openssl)/include" LIBRARY_PATH="$(brew --prefix openssl)/lib" go build ./...
+      run: C_INCLUDE_PATH="$(brew --prefix openssl)/include" LIBRARY_PATH="$(brew --prefix openssl)/lib" go test ./...
   test-windows:
     strategy:
       matrix:

--- a/attest/attest_simulated_tpm20_test.go
+++ b/attest/attest_simulated_tpm20_test.go
@@ -12,12 +12,10 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-// +build linux
 // +build !localtest !tpm12
 // +build cgo
 
 // NOTE: simulator requires cgo, hence the build tag.
-// NOTE: currently requires linuxCmdChannel, which is only defined on Linux.
 
 package attest
 
@@ -35,7 +33,7 @@ func setupSimulatedTPM(t *testing.T) (*simulator.Simulator, *TPM) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	attestTPM, err := OpenTPM(&OpenConfig{CommandChannel: &linuxCmdChannel{tpm}})
+	attestTPM, err := OpenTPM(&OpenConfig{CommandChannel: &fakeCmdChannel{tpm}})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Windows still requires openssl due to tpm-tools simulator. Will try to
figure out that next.

Updates #240