### PR TITLE
attest: Make PCRs included in quote configurable

### DIFF
--- a/attest/attest.go
+++ b/attest/attest.go
@@ -101,7 +101,7 @@ type ak interface {
 	close(tpmBase) error
 	marshal() ([]byte, error)
 	activateCredential(tpm tpmBase, in EncryptedCredential) ([]byte, error)
-	quote(t tpmBase, nonce []byte, alg HashAlg) (*Quote, error)
+	quote(t tpmBase, nonce []byte, alg HashAlg, selectedPCRs []int) (*Quote, error)
 	attestationParameters() AttestationParameters
 	certify(tb tpmBase, handle interface{}) (*CertificationParameters, error)
 }
@@ -136,8 +136,8 @@ func (k *AK) ActivateCredential(tpm *TPM, in EncryptedCredential) (secret []byte
 //
 // This is a low-level API. Consumers seeking to attest the state of the
 // platform should use tpm.AttestPlatform() instead.
-func (k *AK) Quote(tpm *TPM, nonce []byte, alg HashAlg) (*Quote, error) {
-	return k.ak.quote(tpm.tpm, nonce, alg)
+func (k *AK) Quote(tpm *TPM, nonce []byte, alg HashAlg, selectedPCRs []int) (*Quote, error) {
+	return k.ak.quote(tpm.tpm, nonce, alg, selectedPCRs)
 }
 
 // AttestationParameters returns information about the AK, typically used to

--- a/attest/key_linux.go
+++ b/attest/key_linux.go
@@ -64,13 +64,16 @@ func (k *trousersKey12) activateCredential(tb tpmBase, in EncryptedCredential) (
 	return cred, nil
 }
 
-func (k *trousersKey12) quote(tb tpmBase, nonce []byte, alg HashAlg) (*Quote, error) {
+func (k *trousersKey12) quote(tb tpmBase, nonce []byte, alg HashAlg, selectedPCRs []int) (*Quote, error) {
 	t, ok := tb.(*trousersTPM)
 	if !ok {
 		return nil, fmt.Errorf("expected *linuxTPM, got %T", tb)
 	}
 	if alg != HashSHA1 {
 		return nil, fmt.Errorf("only SHA1 algorithms supported on TPM 1.2, not %v", alg)
+	}
+	if selectedPCRs != nil {
+		return nil, fmt.Errorf("selecting PCRs not supported on TPM 1.2 (parameter must be nil)")
 	}
 
 	quote, rawSig, err := attestation.GetQuote(t.ctx, k.blob, nonce)

--- a/attest/key_windows.go
+++ b/attest/key_windows.go
@@ -60,7 +60,7 @@ func (k *windowsKey12) activateCredential(t tpmBase, in EncryptedCredential) ([]
 	return decryptCredential(secretKey, in.Secret)
 }
 
-func (k *windowsKey12) quote(tb tpmBase, nonce []byte, alg HashAlg) (*Quote, error) {
+func (k *windowsKey12) quote(tb tpmBase, nonce []byte, alg HashAlg, selectedPCRs []int) (*Quote, error) {
 	if alg != HashSHA1 {
 		return nil, fmt.Errorf("only SHA1 algorithms supported on TPM 1.2, not %v", alg)
 	}
@@ -77,11 +77,6 @@ func (k *windowsKey12) quote(tb tpmBase, nonce []byte, alg HashAlg) (*Quote, err
 	tpm, err := t.pcp.TPMCommandInterface()
 	if err != nil {
 		return nil, fmt.Errorf("TPMCommandInterface() failed: %v", err)
-	}
-
-	selectedPCRs := make([]int, 24)
-	for pcr, _ := range selectedPCRs {
-		selectedPCRs[pcr] = pcr
 	}
 
 	sig, pcrc, err := tpm1.Quote(tpm, tpmKeyHnd, nonce, selectedPCRs[:], wellKnownAuth[:])
@@ -159,7 +154,7 @@ func (k *windowsKey20) activateCredential(t tpmBase, in EncryptedCredential) ([]
 	return tpm.pcp.ActivateCredential(k.hnd, append(in.Credential, in.Secret...))
 }
 
-func (k *windowsKey20) quote(tb tpmBase, nonce []byte, alg HashAlg) (*Quote, error) {
+func (k *windowsKey20) quote(tb tpmBase, nonce []byte, alg HashAlg, selectedPCRs []int) (*Quote, error) {
 	t, ok := tb.(*windowsTPM)
 	if !ok {
 		return nil, fmt.Errorf("expected *windowsTPM, got %T", tb)

--- a/attest/tpm.go
+++ b/attest/tpm.go
@@ -231,12 +231,9 @@ func readEKCertFromNVRAM20(tpm io.ReadWriter) (*x509.Certificate, error) {
 	return ParseEKCertificate(ekCert)
 }
 
-func quote20(tpm io.ReadWriter, akHandle tpmutil.Handle, hashAlg tpm2.Algorithm, nonce []byte) (*Quote, error) {
-	sel := tpm2.PCRSelection{Hash: hashAlg}
-	numPCRs := 24
-	for pcr := 0; pcr < numPCRs; pcr++ {
-		sel.PCRs = append(sel.PCRs, pcr)
-	}
+func quote20(tpm io.ReadWriter, akHandle tpmutil.Handle, hashAlg tpm2.Algorithm, nonce []byte, selectedPCRs []int) (*Quote, error) {
+	sel := tpm2.PCRSelection{Hash: hashAlg,
+		PCRs: selectedPCRs}
 
 	quote, sig, err := tpm2.Quote(tpm, akHandle, "", "", nonce, sel, tpm2.AlgNull)
 	if err != nil {
@@ -391,7 +388,13 @@ func (t *TPM) attestPCRs(ak *AK, nonce []byte, alg HashAlg) (*Quote, []PCR, erro
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read %v PCRs: %v", alg, err)
 	}
-	quote, err := ak.Quote(t, nonce, alg)
+
+	selectedPCRs := make([]int, 24)
+	for pcr, _ := range selectedPCRs {
+		selectedPCRs[pcr] = pcr
+	}
+
+	quote, err := ak.Quote(t, nonce, alg, selectedPCRs)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to quote using %v: %v", alg, err)
 	}

--- a/attest/wrapped_tpm20.go
+++ b/attest/wrapped_tpm20.go
@@ -476,12 +476,12 @@ func (k *wrappedKey20) certify(tb tpmBase, handle interface{}) (*CertificationPa
 	return certify(t.rwc, hnd, k.hnd, scheme)
 }
 
-func (k *wrappedKey20) quote(tb tpmBase, nonce []byte, alg HashAlg) (*Quote, error) {
+func (k *wrappedKey20) quote(tb tpmBase, nonce []byte, alg HashAlg, selectedPCRs []int) (*Quote, error) {
 	t, ok := tb.(*wrappedTPM20)
 	if !ok {
 		return nil, fmt.Errorf("expected *wrappedTPM20, got %T", tb)
 	}
-	return quote20(t.rwc, k.hnd, tpm2.Algorithm(alg), nonce)
+	return quote20(t.rwc, k.hnd, tpm2.Algorithm(alg), nonce, selectedPCRs)
 }
 
 func (k *wrappedKey20) attestationParameters() AttestationParameters {


### PR DESCRIPTION
It would be nice, if the PCRs to be included in a Quote could be configured in the low-level API (k *Ak) Quote() method. This would enable attesting only parts of the PCRs (e.g. from PCR17 in a DRTM setup). It does not change the usually used tpm.AttestPlatform() method. I created this pull request to check if this has any chance of getting accepted.

I implemented the change for Windows TPM 1.2 and 2.0 and Linux TPM 2.0. I did not implement the change for the Linux TPM 1.2 as it uses the GetQuote() (https://github.com/google/go-tspi/blob/master/attestation/attestation.go#L149) function of the go-tspi (https://github.com/google/go-tspi) library which also does not support specifying the quote. Currently, I just implemented an error if one tries to specify the PCRs for the Linux TPM 1.2. Of course, I could also propose a PR there to add the PCR selection to the GetQuote() function.  I just wanted to check first, if this PR has any chance of getting accepted. If so, I could of course also sign a CLA. 