### PR TITLE
Remove certificate-transparency-go dependency 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,11 @@ on:
     branches: [master]
   pull_request:
 
+# Workaround for SHA1 on Go 1.18. There are some kinks to be worked out. See
+# the tracking issue for more info: https://github.com/golang/go/issues/41682
+env:
+  GODEBUG: x509sha1=1
+
 name: Test
 jobs:
   test-linux:

--- a/attest/application_key_test.go
+++ b/attest/application_key_test.go
@@ -28,11 +28,10 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
 	"encoding/asn1"
 	"math/big"
 	"testing"
-
-	"github.com/google/certificate-transparency-go/x509"
 )
 
 func TestSimTPM20KeyCreateAndLoad(t *testing.T) {

--- a/attest/attest-tool/attest-tool.go
+++ b/attest/attest-tool/attest-tool.go
@@ -6,6 +6,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
@@ -15,7 +16,6 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/go-attestation/attest"
 	"github.com/google/go-attestation/attest/attest-tool/internal"
 )

--- a/attest/attest.go
+++ b/attest/attest.go
@@ -17,12 +17,12 @@ package attest
 
 import (
 	"crypto"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"io"
 	"strings"
 
-	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/go-tpm/tpm"
 	"github.com/google/go-tpm/tpm2"
 )

--- a/attest/challenge_test.go
+++ b/attest/challenge_test.go
@@ -4,9 +4,8 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
 	"testing"
-
-	"github.com/google/certificate-transparency-go/x509"
 )
 
 func TestMakeActivationBlob(t *testing.T) {

--- a/attest/internal/events.go
+++ b/attest/internal/events.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"bytes"
 	"crypto/x509"
-	"encoding/asn1"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -443,13 +442,11 @@ func parseEfiSignature(b []byte) ([]x509.Certificate, error) {
 	} else {
 		// A bug in shim may cause an event to be missing the SignatureOwner GUID.
 		// We handle this, but signal back to the caller using ErrSigMissingGUID.
-		if _, isStructuralErr := err.(asn1.StructuralError); isStructuralErr {
-			var err2 error
-			cert, err2 = x509.ParseCertificate(b)
-			if err2 == nil {
-				certificates = append(certificates, *cert)
-				err = ErrSigMissingGUID
-			}
+		var err2 error
+		cert, err2 = x509.ParseCertificate(b)
+		if err2 == nil {
+			certificates = append(certificates, *cert)
+			err = ErrSigMissingGUID
 		}
 	}
 	return certificates, err

--- a/attest/internal/events.go
+++ b/attest/internal/events.go
@@ -2,14 +2,13 @@ package internal
 
 import (
 	"bytes"
+	"crypto/x509"
+	"encoding/asn1"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
 	"unicode/utf16"
-
-	"github.com/google/certificate-transparency-go/asn1"
-	"github.com/google/certificate-transparency-go/x509"
 )
 
 const (

--- a/attest/pcp_windows.go
+++ b/attest/pcp_windows.go
@@ -19,13 +19,12 @@ package attest
 
 import (
 	"bytes"
+	"crypto/x509"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"syscall"
 	"unsafe"
-
-	"github.com/google/certificate-transparency-go/x509"
 
 	"github.com/google/go-tpm/tpmutil"
 	tpmtbs "github.com/google/go-tpm/tpmutil/tbs"

--- a/attest/secureboot.go
+++ b/attest/secureboot.go
@@ -16,10 +16,10 @@ package attest
 
 import (
 	"bytes"
+	"crypto/x509"
 	"errors"
 	"fmt"
 
-	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/go-attestation/attest/internal"
 )
 

--- a/attest/secureboot_test.go
+++ b/attest/secureboot_test.go
@@ -114,12 +114,12 @@ func TestSecureBootBug157(t *testing.T) {
 
 	events, err := elr.Verify(pcrs)
 	if err != nil {
-		t.Errorf("failed to verify log: %v", err)
+		t.Fatalf("failed to verify log: %v", err)
 	}
 
 	sbs, err := ParseSecurebootState(events)
 	if err != nil {
-		t.Errorf("failed parsing secureboot state: %v", err)
+		t.Fatalf("failed parsing secureboot state: %v", err)
 	}
 	if got, want := len(sbs.PostSeparatorAuthority), 3; got != want {
 		t.Errorf("len(sbs.PostSeparatorAuthority) = %d, want %d", got, want)

--- a/attest/tpm.go
+++ b/attest/tpm.go
@@ -18,14 +18,13 @@ import (
 	"bytes"
 	"crypto/rsa"
 	"crypto/sha256"
+	"crypto/x509"
+	"encoding/asn1"
 	"encoding/base64"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"strings"
-
-	"github.com/google/certificate-transparency-go/asn1"
-	"github.com/google/certificate-transparency-go/x509"
 
 	"github.com/google/go-tpm/tpm2"
 	"github.com/google/go-tpm/tpmutil"
@@ -199,12 +198,12 @@ func ParseEKCertificate(ekCert []byte) (*x509.Certificate, error) {
 	var cert struct {
 		Raw asn1.RawContent
 	}
-	if _, err := asn1.UnmarshalWithParams(ekCert, &cert, "lax"); err != nil && x509.IsFatal(err) {
+	if _, err := asn1.UnmarshalWithParams(ekCert, &cert, "lax"); err != nil {
 		return nil, fmt.Errorf("asn1.Unmarshal() failed: %v, wasWrapped=%v", err, wasWrapped)
 	}
 
 	c, err := x509.ParseCertificate(cert.Raw)
-	if err != nil && x509.IsFatal(err) {
+	if err != nil {
 		return nil, fmt.Errorf("x509.ParseCertificate() failed: %v", err)
 	}
 	return c, nil

--- a/attest/tpm12_linux.go
+++ b/attest/tpm12_linux.go
@@ -19,11 +19,11 @@ package attest
 
 import (
 	"crypto"
+	"crypto/x509"
 	"encoding/binary"
 	"fmt"
 	"io/ioutil"
 
-	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/go-tspi/attestation"
 	"github.com/google/go-tspi/tspi"
 	"github.com/google/go-tspi/tspiconst"

--- a/attest/tpm_test.go
+++ b/attest/tpm_test.go
@@ -2,11 +2,10 @@ package attest
 
 import (
 	"crypto/rsa"
+	"crypto/x509"
 	"encoding/pem"
 	"fmt"
 	"testing"
-
-	"github.com/google/certificate-transparency-go/x509"
 )
 
 // Generated using the following command:

--- a/attest/wrapped_tpm20.go
+++ b/attest/wrapped_tpm20.go
@@ -19,12 +19,12 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rsa"
+	"encoding/asn1"
 	"errors"
 	"fmt"
 	"io"
 	"math/big"
 
-	"github.com/google/certificate-transparency-go/asn1"
 	"github.com/google/go-tpm/tpm2"
 	"github.com/google/go-tpm/tpmutil"
 )

--- a/attributecert/attributecert.go
+++ b/attributecert/attributecert.go
@@ -9,15 +9,15 @@ package attributecert
 import (
 	"bytes"
 	"crypto"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
 	"errors"
 	"fmt"
 	"math/big"
 	"time"
 
 	"github.com/google/go-attestation/oid"
-	"github.com/google/certificate-transparency-go/asn1"
-	"github.com/google/certificate-transparency-go/x509/pkix"
-	"github.com/google/certificate-transparency-go/x509"
 )
 
 var (

--- a/attributecert/attributecert_test.go
+++ b/attributecert/attributecert_test.go
@@ -15,13 +15,12 @@
 package attributecert
 
 import (
+	"crypto/x509"
 	"encoding/json"
 	"io/ioutil"
 	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/google/certificate-transparency-go/x509"
 )
 
 func TestVerifyAttributeCert(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/google/go-attestation
 go 1.16
 
 require (
-	github.com/google/certificate-transparency-go v1.1.1
 	github.com/google/go-cmp v0.5.7
 	github.com/google/go-tpm v0.3.3
 	github.com/google/go-tpm-tools v0.3.1


### PR DESCRIPTION
Fixes #247

Having non-standard x509 structures in the external API makes it very difficult to integrate with other libraries (see https://github.com/google/go-tpm-tools/pull/178). Furthermore, must of the certificate-transparency related differences are not longer needed now that https://github.com/google/go-attestation/issues/92 is fixed.

Looking at the past issues and PRs, I found three places where we needed certificate-transparency-go:
  - https://github.com/google/go-attestation/pull/3
    - No longer needed as `x509.RSAESOAEP` isn't used anymore in this library
  - https://github.com/google/go-attestation/pull/41
    - Using the Standard Library's `asn1` package doesn't seem to cause any issues (all tests pass).
    - The `parseCert` function and use of `asn1.UnmarshalWithParams` no longer exist
  - @twitchy-jsonp's comment https://github.com/google/go-attestation/issues/92#issuecomment-526681092
    -  Overriding `UnhandledCriticalExtensions` and `KeyUsages` can be done with the Standard Library's `x509` package.

The only code changes necessary to get a tests to pass was:
  - Properly use `Fatalf` (instead of `Errorf`)
  - Don't use `x509.IsFatal(err)` as non-fatal errors don't exist in the standard library
  - Don't depend on the exact error code returned by `x509.ParseCertificate` (this wasn't stable anyway)
    - We just unconditionally try the workaround for https://github.com/google/go-attestation/issues/157 if cert parsing fails.

Even if we eventually decide we need to _internally_ use certificate-transparency-go in a few limited places, we should use the standard library types in the external API, `attest.SecurebootState` for example.