### PR TITLE
Fixup CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+
 name: Test
 jobs:
   test-linux:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
   test-linux:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.16.x, 1.17.x, 1.18.x]
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
@@ -22,7 +22,7 @@ jobs:
   test-linux-tpm12:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.16.x, 1.17.x, 1.18.x]
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
@@ -38,7 +38,7 @@ jobs:
   test-macos:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.16.x, 1.17.x, 1.18.x]
     runs-on: macos-latest
     steps:
     - name: Install Go
@@ -57,7 +57,7 @@ jobs:
   test-windows:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.16.x, 1.17.x, 1.18.x]
     runs-on: windows-latest
     steps:
     - name: Install Go


### PR DESCRIPTION
First commit makes sure that the CI doesn't run twice when opening a PR against a non-master branch.

Second commit runs the CI for Go 1.18