### PR TITLE
attest: Make PCRs included in quote configurable

### DIFF
--- a/attest/attest.go
+++ b/attest/attest.go
@@ -103,7 +103,7 @@ type ak interface {
 	close(tpmBase) error
 	marshal() ([]byte, error)
 	activateCredential(tpm tpmBase, in EncryptedCredential, ek *EK) ([]byte, error)
-	quote(t tpmBase, nonce []byte, alg HashAlg) (*Quote, error)
+	quote(t tpmBase, nonce []byte, alg HashAlg, selectedPCRs []int) (*Quote, error)
 	attestationParameters() AttestationParameters
 	certify(tb tpmBase, handle interface{}) (*CertificationParameters, error)
 }
@@ -143,7 +143,16 @@ func (k *AK) ActivateCredential(tpm *TPM, in EncryptedCredential) (secret []byte
 // This is a low-level API. Consumers seeking to attest the state of the
 // platform should use tpm.AttestPlatform() instead.
 func (k *AK) Quote(tpm *TPM, nonce []byte, alg HashAlg) (*Quote, error) {
-	return k.ak.quote(tpm.tpm, nonce, alg)
+	pcrs := make([]int, 24)
+	for pcr := range pcrs {
+		pcrs[pcr] = pcr
+	}
+	return k.ak.quote(tpm.tpm, nonce, alg, pcrs)
+}
+
+// QuotePCRs is like Quote() but allows the caller to select a subset of the PCRs.
+func (k *AK) QuotePCRs(tpm *TPM, nonce []byte, alg HashAlg, pcrs []int) (*Quote, error) {
+	return k.ak.quote(tpm.tpm, nonce, alg, pcrs)
 }
 
 // AttestationParameters returns information about the AK, typically used to

--- a/attest/key_linux.go
+++ b/attest/key_linux.go
@@ -65,13 +65,16 @@ func (k *trousersKey12) activateCredential(tb tpmBase, in EncryptedCredential, e
 	return cred, nil
 }
 
-func (k *trousersKey12) quote(tb tpmBase, nonce []byte, alg HashAlg) (*Quote, error) {
+func (k *trousersKey12) quote(tb tpmBase, nonce []byte, alg HashAlg, selectedPCRs []int) (*Quote, error) {
 	t, ok := tb.(*trousersTPM)
 	if !ok {
 		return nil, fmt.Errorf("expected *linuxTPM, got %T", tb)
 	}
 	if alg != HashSHA1 {
 		return nil, fmt.Errorf("only SHA1 algorithms supported on TPM 1.2, not %v", alg)
+	}
+	if selectedPCRs != nil {
+		return nil, fmt.Errorf("selecting PCRs not supported on TPM 1.2 (parameter must be nil)")
 	}
 
 	quote, rawSig, err := attestation.GetQuote(t.ctx, k.blob, nonce)

--- a/attest/wrapped_tpm20.go
+++ b/attest/wrapped_tpm20.go
@@ -518,12 +518,12 @@ func (k *wrappedKey20) certify(tb tpmBase, handle interface{}) (*CertificationPa
 	return certify(t.rwc, hnd, k.hnd, scheme)
 }
 
-func (k *wrappedKey20) quote(tb tpmBase, nonce []byte, alg HashAlg) (*Quote, error) {
+func (k *wrappedKey20) quote(tb tpmBase, nonce []byte, alg HashAlg, selectedPCRs []int) (*Quote, error) {
 	t, ok := tb.(*wrappedTPM20)
 	if !ok {
 		return nil, fmt.Errorf("expected *wrappedTPM20, got %T", tb)
 	}
-	return quote20(t.rwc, k.hnd, tpm2.Algorithm(alg), nonce)
+	return quote20(t.rwc, k.hnd, tpm2.Algorithm(alg), nonce, selectedPCRs)
 }
 
 func (k *wrappedKey20) attestationParameters() AttestationParameters {


### PR DESCRIPTION
This is an update of https://github.com/google/go-attestation/pull/254, now from my corporate account with a signed CLA. 

The PR introduces an additional function QuotePCRs which is like the existing Quote() but allows configuring the PCRs to be included in a quote. This enables attesting only parts of the PCRs (e.g. from PCR17 in a DRTM setup). 

@ericchiang I addressed your feedback to not introduce any breaking API changes.
