### PR TITLE
Make AttestationParameters.CreateData optional

### DIFF
--- a/attest/activation.go
+++ b/attest/activation.go
@@ -97,10 +97,14 @@ func (p *ActivationParameters) checkTPM20AKParameters() error {
 	if err != nil {
 		return fmt.Errorf("DecodePublic() failed: %v", err)
 	}
-	_, err = tpm2.DecodeCreationData(p.AK.CreateData)
-	if err != nil {
-		return fmt.Errorf("DecodeCreationData() failed: %v", err)
+
+	if len(p.AK.CreateData) > 0 {
+		_, err = tpm2.DecodeCreationData(p.AK.CreateData)
+		if err != nil {
+			return fmt.Errorf("DecodeCreationData() failed: %v", err)
+		}
 	}
+
 	att, err := tpm2.DecodeAttestationData(p.AK.CreateAttestation)
 	if err != nil {
 		return fmt.Errorf("DecodeAttestationData() failed: %v", err)


### PR DESCRIPTION
Make AttestationParameters.CreateData optional

Fixes: issues/321.
Parent: pull/322.

Makes AttestationParameters.CreateData an optional field when
verifying ActivationParameters to generate a TPM2.0 activation
challenge.

cc @ericchiang 