### PR TITLE
[Refactoring] Renamed wrappedTPM20.getPrimaryKeyHandle() into

### DIFF
--- a/attest/attest_simulated_tpm20_test.go
+++ b/attest/attest_simulated_tpm20_test.go
@@ -250,22 +250,13 @@ func TestSimTPM20Persistence(t *testing.T) {
 	sim, tpm := setupSimulatedTPM(t)
 	defer sim.Close()
 
-	ekHnd, _, err := tpm.tpm.(*wrappedTPM20).getPrimaryKeyHandle(commonEkEquivalentHandle)
+	err := tpm.tpm.(*wrappedTPM20).persistHandle(commonEkEquivalentHandle)
 	if err != nil {
-		t.Fatalf("getPrimaryKeyHandle() failed: %v", err)
-	}
-	if ekHnd != commonEkEquivalentHandle {
-		t.Fatalf("bad EK-equivalent handle: got 0x%x, wanted 0x%x", ekHnd, commonEkEquivalentHandle)
+		t.Fatalf("persistHandle() failed: %v", err)
 	}
 
-	ekHnd, p, err := tpm.tpm.(*wrappedTPM20).getPrimaryKeyHandle(commonEkEquivalentHandle)
+	err = tpm.tpm.(*wrappedTPM20).persistHandle(commonEkEquivalentHandle)
 	if err != nil {
-		t.Fatalf("second getPrimaryKeyHandle() failed: %v", err)
-	}
-	if ekHnd != commonEkEquivalentHandle {
-		t.Fatalf("bad EK-equivalent handle: got 0x%x, wanted 0x%x", ekHnd, commonEkEquivalentHandle)
-	}
-	if p {
-		t.Fatalf("generated a new key the second time; that shouldn't happen")
+		t.Fatalf("second persistHandle() failed: %v", err)
 	}
 }


### PR DESCRIPTION
persistHandle() to reflect what the method actually does.

Looking at the implementation, it seems that getPrimaryKeyHandle() merely ensures that the corresponding object is persisted in the TPM. Also the method's first return value is always the method's argument pHnd (if no error occured), thus the first return value may be redundant. And nowhere in the code the second return value, "whether we generated a new one", is used; thus it can be safely removed.

Hopefuly this refactoring makes it clearer what the method intends to do.