### PR TITLE
Renamed some variables and methods to highlight that only RSA EKs are

### DIFF
--- a/attest/attest_simulated_tpm20_test.go
+++ b/attest/attest_simulated_tpm20_test.go
@@ -250,20 +250,20 @@ func TestSimTPM20Persistence(t *testing.T) {
 	sim, tpm := setupSimulatedTPM(t)
 	defer sim.Close()
 
-	ekHnd, _, err := tpm.tpm.(*wrappedTPM20).getPrimaryKeyHandle(commonEkEquivalentHandle)
+	ekHnd, _, err := tpm.tpm.(*wrappedTPM20).getPrimaryKeyHandle(commonRSAEkEquivalentHandle)
 	if err != nil {
 		t.Fatalf("getPrimaryKeyHandle() failed: %v", err)
 	}
-	if ekHnd != commonEkEquivalentHandle {
-		t.Fatalf("bad EK-equivalent handle: got 0x%x, wanted 0x%x", ekHnd, commonEkEquivalentHandle)
+	if ekHnd != commonRSAEkEquivalentHandle {
+		t.Fatalf("bad EK-equivalent handle: got 0x%x, wanted 0x%x", ekHnd, commonRSAEkEquivalentHandle)
 	}
 
-	ekHnd, p, err := tpm.tpm.(*wrappedTPM20).getPrimaryKeyHandle(commonEkEquivalentHandle)
+	ekHnd, p, err := tpm.tpm.(*wrappedTPM20).getPrimaryKeyHandle(commonRSAEkEquivalentHandle)
 	if err != nil {
 		t.Fatalf("second getPrimaryKeyHandle() failed: %v", err)
 	}
-	if ekHnd != commonEkEquivalentHandle {
-		t.Fatalf("bad EK-equivalent handle: got 0x%x, wanted 0x%x", ekHnd, commonEkEquivalentHandle)
+	if ekHnd != commonRSAEkEquivalentHandle {
+		t.Fatalf("bad EK-equivalent handle: got 0x%x, wanted 0x%x", ekHnd, commonRSAEkEquivalentHandle)
 	}
 	if p {
 		t.Fatalf("generated a new key the second time; that shouldn't happen")

--- a/attest/tpm.go
+++ b/attest/tpm.go
@@ -37,12 +37,12 @@ const (
 	tpmPtFwVersion1   = 0x00000100 + 11 // PT_FIXED + offset of 11
 
 	// Defined in "Registry of reserved TPM 2.0 handles and localities".
-	nvramCertIndex    = 0x1c00002
-	nvramEkNonceIndex = 0x1c00003
+	nvramRSACertIndex    = 0x1c00002
+	nvramRSAEkNonceIndex = 0x1c00003
 
 	// Defined in "Registry of reserved TPM 2.0 handles and localities", and checked on a glinux machine.
-	commonSrkEquivalentHandle = 0x81000001
-	commonEkEquivalentHandle  = 0x81010001
+	commonSrkEquivalentHandle   = 0x81000001
+	commonRSAEkEquivalentHandle = 0x81010001
 )
 
 var (
@@ -72,9 +72,9 @@ var (
 			KeyBits:    2048,
 		},
 	}
-	// Default EK template defined in:
+	// Default RSA EK template defined in:
 	// https://trustedcomputinggroup.org/wp-content/uploads/Credential_Profile_EK_V2.0_R14_published.pdf
-	defaultEKTemplate = tpm2.Public{
+	defaultRSAEKTemplate = tpm2.Public{
 		Type:    tpm2.AlgRSA,
 		NameAlg: tpm2.AlgSHA256,
 		Attributes: tpm2.FlagFixedTPM | tpm2.FlagFixedParent | tpm2.FlagSensitiveDataOrigin |
@@ -223,7 +223,7 @@ func intelEKURL(ekPub *rsa.PublicKey) string {
 	return intelEKCertServiceURL + url.QueryEscape(base64.URLEncoding.EncodeToString(pubHash.Sum(nil)))
 }
 
-func readEKCertFromNVRAM20(tpm io.ReadWriter) (*x509.Certificate, error) {
+func readEKCertFromNVRAM20(tpm io.ReadWriter, nvramCertIndex tpmutil.Handle) (*x509.Certificate, error) {
 	// By passing nvramCertIndex as our auth handle we're using the NV index
 	// itself as the auth hierarchy, which is the same approach
 	// tpm2_getekcertificate takes.


### PR DESCRIPTION
Renamed some variables and methods to highlight that only RSA EKs are currently supported.

This is the first step towards supporting ECC EKs.