### PR TITLE
use legacy tpm2 at its new path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   test-linux:
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.20.x]
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
@@ -27,7 +27,7 @@ jobs:
   test-linux-tpm12:
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.20.x]
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
@@ -43,7 +43,7 @@ jobs:
   test-macos:
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.20.x]
     runs-on: macos-latest
     steps:
     - name: Install Go
@@ -62,7 +62,7 @@ jobs:
   test-windows:
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.20.x]
     runs-on: windows-latest
     steps:
     - name: Install Go

--- a/attest/activation.go
+++ b/attest/activation.go
@@ -9,11 +9,11 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/google/go-tpm/legacy/tpm2"
 	tpm1 "github.com/google/go-tpm/tpm"
-	"github.com/google/go-tpm/tpm2"
 
 	// TODO(jsonp): Move activation generation code to internal package.
-	"github.com/google/go-tpm/tpm2/credactivation"
+	"github.com/google/go-tpm/legacy/tpm2/credactivation"
 	"github.com/google/go-tspi/verification"
 )
 

--- a/attest/attest-tool/internal/internal.go
+++ b/attest/attest-tool/internal/internal.go
@@ -3,7 +3,7 @@ package internal
 
 import (
 	"github.com/google/go-attestation/attest"
-	"github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/legacy/tpm2"
 )
 
 // Dump describes the layout of serialized information from the dump command.

--- a/attest/attest.go
+++ b/attest/attest.go
@@ -23,8 +23,8 @@ import (
 	"io"
 	"strings"
 
+	"github.com/google/go-tpm/legacy/tpm2"
 	"github.com/google/go-tpm/tpm"
-	"github.com/google/go-tpm/tpm2"
 )
 
 // TPMVersion is used to configure a preference in

--- a/attest/certification.go
+++ b/attest/certification.go
@@ -23,8 +23,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/google/go-tpm/tpm2"
-	"github.com/google/go-tpm/tpm2/credactivation"
+	"github.com/google/go-tpm/legacy/tpm2"
+	"github.com/google/go-tpm/legacy/tpm2/credactivation"
 	"github.com/google/go-tpm/tpmutil"
 )
 

--- a/attest/certification_test.go
+++ b/attest/certification_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/legacy/tpm2"
 )
 
 func TestSimTPM20CertificationParameters(t *testing.T) {

--- a/attest/eventlog.go
+++ b/attest/eventlog.go
@@ -30,7 +30,7 @@ import (
 	// Ensure hashes are available.
 	_ "crypto/sha256"
 
-	"github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/legacy/tpm2"
 	"github.com/google/go-tpm/tpmutil"
 )
 

--- a/attest/eventlog_test.go
+++ b/attest/eventlog_test.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/legacy/tpm2"
 )
 
 // Dump describes the layout of serialized information from the dump command.

--- a/attest/key_windows.go
+++ b/attest/key_windows.go
@@ -20,8 +20,8 @@ package attest
 import (
 	"fmt"
 
+	"github.com/google/go-tpm/legacy/tpm2"
 	tpm1 "github.com/google/go-tpm/tpm"
-	"github.com/google/go-tpm/tpm2"
 )
 
 // windowsKey12 represents a Windows-managed key on a TPM1.2 TPM.

--- a/attest/tpm.go
+++ b/attest/tpm.go
@@ -27,7 +27,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/legacy/tpm2"
 	"github.com/google/go-tpm/tpmutil"
 )
 

--- a/attest/tpm_linux.go
+++ b/attest/tpm_linux.go
@@ -25,7 +25,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/legacy/tpm2"
 )
 
 const (

--- a/attest/wrapped_tpm20.go
+++ b/attest/wrapped_tpm20.go
@@ -26,7 +26,7 @@ import (
 	"io"
 	"math/big"
 
-	"github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/legacy/tpm2"
 	"github.com/google/go-tpm/tpmutil"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/google/go-attestation
 
-go 1.19
+go 1.20
 
 require (
 	github.com/google/go-cmp v0.5.9
-	github.com/google/go-tpm v0.3.3
+	github.com/google/go-tpm v0.3.4-0.20230613064043-511507721cb1
 	github.com/google/go-tpm-tools v0.3.12
 	github.com/google/go-tspi v0.3.0
 	golang.org/x/sys v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -304,12 +304,8 @@ github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO
 github.com/google/go-replayers/grpcreplay v0.1.0/go.mod h1:8Ig2Idjpr6gifRd6pNVggX6TC1Zw6Jx74AKp7QNH2QE=
 github.com/google/go-replayers/httpreplay v0.1.0/go.mod h1:YKZViNhiGgqdBlUbI2MwGpq4pXxNmhJLPHQ7cv2b5no=
 github.com/google/go-sev-guest v0.6.1 h1:NajHkAaLqN9/aW7bCFSUplUMtDgk2+HcN7jC2btFtk0=
-github.com/google/go-tpm v0.1.2-0.20190725015402-ae6dd98980d4/go.mod h1:H9HbmUG2YgV/PHITkO7p6wxEEj/v5nlsVWIwumwH2NI=
-github.com/google/go-tpm v0.3.0/go.mod h1:iVLWvrPp/bHeEkxTFi9WG6K9w0iy2yIszHwZGHPbzAw=
-github.com/google/go-tpm v0.3.3 h1:P/ZFNBZYXRxc+z7i5uyd8VP7MaDteuLZInzrH2idRGo=
-github.com/google/go-tpm v0.3.3/go.mod h1:9Hyn3rgnzWF9XBWVk6ml6A6hNkbWjNFlDQL51BeghL4=
-github.com/google/go-tpm-tools v0.0.0-20190906225433-1614c142f845/go.mod h1:AVfHadzbdzHo54inR2x1v640jdi1YSi3NauM2DUsxk0=
-github.com/google/go-tpm-tools v0.2.0/go.mod h1:npUd03rQ60lxN7tzeBJreG38RvWwme2N1reF/eeiBk4=
+github.com/google/go-tpm v0.3.4-0.20230613064043-511507721cb1 h1:wGP91a6fiYbZhKlGcQD25K8XwXzoG4yHAEIjtpeV2QA=
+github.com/google/go-tpm v0.3.4-0.20230613064043-511507721cb1/go.mod h1:Yj9bYgsIKoza8oMlxZqvqgUIDKFaExnuLaDdOtFCwG4=
 github.com/google/go-tpm-tools v0.3.12 h1:hpWglH4RaZnGVbgOK3IThI5K++jnFvjQ94EIN34xrUU=
 github.com/google/go-tpm-tools v0.3.12/go.mod h1:2OtmyPGPuaWWIOjr+IDhNQb6t5njjbSmZtzc350Q6Ro=
 github.com/google/go-tspi v0.3.0 h1:ADtq8RKfP+jrTyIWIZDIYcKOMecRqNJFOew2IT0Inus=
@@ -944,7 +940,6 @@ golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210629170331-7dc0b73dc9fb/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=


### PR DESCRIPTION
As part of releasing go-tpm 0.9.0, we need to update go-tpm-tools to use go-tpm/tpm2 at its new legacy path (go-tpm/legacy/tpm2). However, go-tpm-tools also depends on this package, which depends back on go-tpm-tools.

This change updates go-attestation to depend on go-tpm @ 511507721cb172faf1149ab9e38ff7881eb1b776 (which adds tpmdirect but doesn't yet delete the Startup adapter), and use legacy/tpm2 instead of tpm2. This will allow a future change to go-tpm-tools to do the same.