### PR TITLE
Add EK as a field to AK struct.

### DIFF
--- a/attest/attest_simulated_tpm20_test.go
+++ b/attest/attest_simulated_tpm20_test.go
@@ -98,14 +98,16 @@ func TestSimTPM20AKCreateAndLoad(t *testing.T) {
 }
 
 func TestSimTPM20ActivateCredential(t *testing.T) {
+	testActivateCredential(t, false)
+}
+
+func TestSimTPM20ActivateCredentialWithEK(t *testing.T) {
+	testActivateCredential(t, true)
+}
+
+func testActivateCredential(t *testing.T, useEK bool) {
 	sim, tpm := setupSimulatedTPM(t)
 	defer sim.Close()
-
-	ak, err := tpm.NewAK(nil)
-	if err != nil {
-		t.Fatalf("NewAK() failed: %v", err)
-	}
-	defer ak.Close(tpm)
 
 	EKs, err := tpm.EKs()
 	if err != nil {
@@ -113,10 +115,20 @@ func TestSimTPM20ActivateCredential(t *testing.T) {
 	}
 	ek := chooseEK(t, EKs)
 
+	var akConfig *AKConfig
+	if useEK {
+		akConfig = &AKConfig{EK: &ek}
+	}
+	ak, err := tpm.NewAK(akConfig)
+	if err != nil {
+		t.Fatalf("NewAK() failed: %v", err)
+	}
+	defer ak.Close(tpm)
+
 	ap := ActivationParameters{
 		TPMVersion: TPMVersion20,
 		AK:         ak.AttestationParameters(),
-		EK:         ek,
+		EK:         ek.Public,
 	}
 	secret, challenge, err := ap.Generate()
 	if err != nil {
@@ -246,24 +258,57 @@ func TestSimTPM20PCRs(t *testing.T) {
 	}
 }
 
-func TestSimTPM20Persistence(t *testing.T) {
+func TestSimTPM20PersistenceSRK(t *testing.T) {
 	sim, tpm := setupSimulatedTPM(t)
 	defer sim.Close()
 
-	ekHnd, _, err := tpm.tpm.(*wrappedTPM20).getPrimaryKeyHandle(commonRSAEkEquivalentHandle)
+	srkHnd, _, err := tpm.tpm.(*wrappedTPM20).getStorageRootKeyHandle(commonSrkEquivalentHandle)
 	if err != nil {
-		t.Fatalf("getPrimaryKeyHandle() failed: %v", err)
+		t.Fatalf("getStorageRootKeyHandle() failed: %v", err)
 	}
-	if ekHnd != commonRSAEkEquivalentHandle {
-		t.Fatalf("bad EK-equivalent handle: got 0x%x, wanted 0x%x", ekHnd, commonRSAEkEquivalentHandle)
+	if srkHnd != commonSrkEquivalentHandle {
+		t.Fatalf("bad SRK-equivalent handle: got 0x%x, wanted 0x%x", srkHnd, commonSrkEquivalentHandle)
 	}
 
-	ekHnd, p, err := tpm.tpm.(*wrappedTPM20).getPrimaryKeyHandle(commonRSAEkEquivalentHandle)
+	srkHnd, p, err := tpm.tpm.(*wrappedTPM20).getStorageRootKeyHandle(commonSrkEquivalentHandle)
 	if err != nil {
-		t.Fatalf("second getPrimaryKeyHandle() failed: %v", err)
+		t.Fatalf("second getStorageRootKeyHandle() failed: %v", err)
 	}
-	if ekHnd != commonRSAEkEquivalentHandle {
-		t.Fatalf("bad EK-equivalent handle: got 0x%x, wanted 0x%x", ekHnd, commonRSAEkEquivalentHandle)
+	if srkHnd != commonSrkEquivalentHandle {
+		t.Fatalf("bad SRK-equivalent handle: got 0x%x, wanted 0x%x", srkHnd, commonSrkEquivalentHandle)
+	}
+	if p {
+		t.Fatalf("generated a new key the second time; that shouldn't happen")
+	}
+}
+
+func TestSimTPM20PersistenceEK(t *testing.T) {
+	sim, tpm := setupSimulatedTPM(t)
+	defer sim.Close()
+
+	eks, err := tpm.EKs()
+	if err != nil {
+		t.Errorf("EKs() failed: %v", err)
+	}
+	if len(eks) == 0 || (eks[0].Public == nil) {
+		t.Errorf("EKs() = %v, want at least 1 EK with populated fields", eks)
+	}
+
+	ek := eks[0]
+	ekHnd, _, err := tpm.tpm.(*wrappedTPM20).getEndorsementKeyHandle(&ek)
+	if err != nil {
+		t.Fatalf("getStorageRootKeyHandle() failed: %v", err)
+	}
+	if ekHnd != ek.handle {
+		t.Fatalf("bad EK-equivalent handle: got 0x%x, wanted 0x%x", ekHnd, ek.handle)
+	}
+
+	ekHnd, p, err := tpm.tpm.(*wrappedTPM20).getEndorsementKeyHandle(&ek)
+	if err != nil {
+		t.Fatalf("second getEndorsementKeyHandle() failed: %v", err)
+	}
+	if ekHnd != ek.handle {
+		t.Fatalf("bad EK-equivalent handle: got 0x%x, wanted 0x%x", ekHnd, ek.handle)
 	}
 	if p {
 		t.Fatalf("generated a new key the second time; that shouldn't happen")

--- a/attest/attest_test.go
+++ b/attest/attest_test.go
@@ -16,7 +16,6 @@ package attest
 
 import (
 	"bytes"
-	"crypto"
 	"flag"
 	"fmt"
 	"reflect"
@@ -119,16 +118,16 @@ func TestAKCreateAndLoad(t *testing.T) {
 	}
 }
 
-// chooseEK selects the EK public which will be activated against.
-func chooseEK(t *testing.T, eks []EK) crypto.PublicKey {
+// chooseEK selects the EK which will be activated against.
+func chooseEK(t *testing.T, eks []EK) EK {
 	t.Helper()
 
 	for _, ek := range eks {
-		return ek.Public
+		return ek
 	}
 
 	t.Fatalf("No suitable EK found")
-	return nil
+	return EK{}
 }
 
 func TestPCRs(t *testing.T) {

--- a/attest/attest_tpm12_test.go
+++ b/attest/attest_tpm12_test.go
@@ -151,7 +151,7 @@ func TestTPMActivateCredential(t *testing.T) {
 	ap := ActivationParameters{
 		TPMVersion: TPMVersion12,
 		AK:         ak.AttestationParameters(),
-		EK:         ek,
+		EK:         ek.Public,
 	}
 	secret, challenge, err := ap.Generate()
 	if err != nil {

--- a/attest/key_linux.go
+++ b/attest/key_linux.go
@@ -52,7 +52,7 @@ func (k *trousersKey12) close(tpm tpmBase) error {
 	return nil // No state for tpm 1.2.
 }
 
-func (k *trousersKey12) activateCredential(tb tpmBase, in EncryptedCredential) ([]byte, error) {
+func (k *trousersKey12) activateCredential(tb tpmBase, in EncryptedCredential, ek *EK) ([]byte, error) {
 	t, ok := tb.(*trousersTPM)
 	if !ok {
 		return nil, fmt.Errorf("expected *linuxTPM, got %T", tb)

--- a/attest/key_windows.go
+++ b/attest/key_windows.go
@@ -49,7 +49,7 @@ func (k *windowsKey12) marshal() ([]byte, error) {
 	return out.Serialize()
 }
 
-func (k *windowsKey12) activateCredential(t tpmBase, in EncryptedCredential) ([]byte, error) {
+func (k *windowsKey12) activateCredential(t tpmBase, in EncryptedCredential, ek *EK) ([]byte, error) {
 	tpm, ok := t.(*windowsTPM)
 	if !ok {
 		return nil, fmt.Errorf("expected *windowsTPM, got %T", t)
@@ -152,7 +152,7 @@ func (k *windowsKey20) marshal() ([]byte, error) {
 	return out.Serialize()
 }
 
-func (k *windowsKey20) activateCredential(t tpmBase, in EncryptedCredential) ([]byte, error) {
+func (k *windowsKey20) activateCredential(t tpmBase, in EncryptedCredential, ek *EK) ([]byte, error) {
 	tpm, ok := t.(*windowsTPM)
 	if !ok {
 		return nil, fmt.Errorf("expected *windowsTPM, got %T", t)


### PR DESCRIPTION
The change is a no-op for existing clients, and it will simplify adding the support for ECC EKs. The activation code no longer makes assumptions about EK's type and handle (i.e. RSA and 0x81010001), and instead relies on TPM.EKs() to provide the EK's details.