### PR TITLE
Add TPM.EKCertificates() method.

### DIFF
--- a/attest/tpm.go
+++ b/attest/tpm.go
@@ -39,10 +39,12 @@ const (
 	// Defined in "Registry of reserved TPM 2.0 handles and localities".
 	nvramRSACertIndex    = 0x1c00002
 	nvramRSAEkNonceIndex = 0x1c00003
+	nvramECCCertIndex    = 0x1c0000a
 
 	// Defined in "Registry of reserved TPM 2.0 handles and localities", and checked on a glinux machine.
 	commonSrkEquivalentHandle   = 0x81000001
 	commonRSAEkEquivalentHandle = 0x81010001
+	commonECCEkEquivalentHandle = 0x81010002
 )
 
 var (
@@ -297,6 +299,7 @@ type tpmBase interface {
 	close() error
 	tpmVersion() TPMVersion
 	eks() ([]EK, error)
+	ekCertificates() ([]EK, error)
 	info() (*TPMInfo, error)
 
 	loadAK(opaqueBlob []byte) (*AK, error)
@@ -322,6 +325,12 @@ func (t *TPM) Close() error {
 // EKs returns the endorsement keys burned-in to the platform.
 func (t *TPM) EKs() ([]EK, error) {
 	return t.tpm.eks()
+}
+
+// EKCertificates returns the endorsement key certificates burned-in to the platform.
+// It is guaranteed that each EK.Certificate field will be populated.
+func (t *TPM) EKCertificates() ([]EK, error) {
+	return t.tpm.ekCertificates()
 }
 
 // Info returns information about the TPM.

--- a/attest/tpm12_linux.go
+++ b/attest/tpm12_linux.go
@@ -94,7 +94,7 @@ func readEKCertFromNVRAM12(ctx *tspi.Context) (*x509.Certificate, error) {
 	return ParseEKCertificate(ekCert)
 }
 
-func (t *trousersTPM) eks() ([]EK, error) {
+func (t *trousersTPM) ekCertificates() ([]EK, error) {
 	cert, err := readEKCertFromNVRAM12(t.ctx)
 	if err != nil {
 		return nil, fmt.Errorf("readEKCertFromNVRAM failed: %v", err)
@@ -102,6 +102,10 @@ func (t *trousersTPM) eks() ([]EK, error) {
 	return []EK{
 		{Public: crypto.PublicKey(cert.PublicKey), Certificate: cert},
 	}, nil
+}
+
+func (t *trousersTPM) eks() ([]EK, error) {
+	return t.ekCertificates()
 }
 
 func (t *trousersTPM) newKey(*AK, *KeyConfig) (*Key, error) {

--- a/attest/tpm_windows.go
+++ b/attest/tpm_windows.go
@@ -152,6 +152,18 @@ func (t *windowsTPM) info() (*TPMInfo, error) {
 	return &tInfo, nil
 }
 
+func (t *windowsTPM) ekCertificates() ([]EK, error) {
+	ekCerts, err := t.pcp.EKCerts()
+	if err != nil {
+		return nil, fmt.Errorf("could not read EKCerts: %v", err)
+	}
+	var eks []EK
+	for _, cert := range ekCerts {
+		eks = append(eks, EK{Certificate: cert, Public: cert.PublicKey})
+	}
+	return eks, nil
+}
+
 func (t *windowsTPM) eks() ([]EK, error) {
 	ekCerts, err := t.pcp.EKCerts()
 	if err != nil {


### PR DESCRIPTION
The method returns all certificates from TPM's NVRAM.

This is part of the work for ECC EKs support. The new method will allow the clients to see which EK Certificate (RSA vs. ECC vs. both) is available in the TPM, and the clients will be able to pick the right EK to use in the following attestation process.



