### PR TITLE
Fix golangci-lint workflow

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,9 +10,9 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.3
+          go-version: 1.20.x
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50.1
+          version: v1.53.3


### PR DESCRIPTION
- use go1.20 to follow the [`go.mod`](https://github.com/google/go-attestation/blob/a9b6eb1eb8880c0edc51764f581b326c856fdd3d/go.mod#L3) and the [other workflow](https://github.com/google/go-attestation/blob/a9b6eb1eb8880c0edc51764f581b326c856fdd3d/.github/workflows/test.yml#L16).
- use golangci-lint v1.53.3 to have the support of go1.20

Those elements were missing inside #331: the PR was merged despite the failure of CI and as the 
golangci-lint workflow is [only called for PRs](https://github.com/google/go-attestation/blob/a9b6eb1eb8880c0edc51764f581b326c856fdd3d/.github/workflows/golangci-lint.yml#L2-L3) the failure doesn't appear on the branch `master.`