### PR TITLE
attest: Add AK signing interface

### DIFF
--- a/attest/application_key.go
+++ b/attest/application_key.go
@@ -26,7 +26,7 @@ type key interface {
 	close(tpmBase) error
 	marshal() ([]byte, error)
 	certificationParameters() CertificationParameters
-	sign(tpmBase, []byte, crypto.PublicKey, crypto.SignerOpts) ([]byte, error)
+	sign(tpmBase, []byte, crypto.PublicKey, crypto.SignerOpts, any) ([]byte, error)
 	decrypt(tpmBase, []byte) ([]byte, error)
 	blobs() ([]byte, []byte, error)
 }
@@ -48,7 +48,7 @@ type signer struct {
 
 // Sign signs digest with the TPM-stored private signing key.
 func (s *signer) Sign(r io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
-	return s.key.sign(s.tpm, digest, s.pub, opts)
+	return s.key.sign(s.tpm, digest, s.pub, opts, nil)
 }
 
 // Public returns the public key corresponding to the private signing key.

--- a/attest/key_linux.go
+++ b/attest/key_linux.go
@@ -18,6 +18,8 @@
 package attest
 
 import (
+	"crypto"
+	"errors"
 	"fmt"
 
 	"github.com/google/go-tspi/attestation"
@@ -98,4 +100,8 @@ func (k *trousersKey12) attestationParameters() AttestationParameters {
 
 func (k *trousersKey12) certify(tb tpmBase, handle interface{}) (*CertificationParameters, error) {
 	return nil, fmt.Errorf("not implemented")
+}
+
+func (k *trousersKey12) sign(tb tpmBase, digest []byte, pub crypto.PublicKey, opts crypto.SignerOpts, validation any) ([]byte, error) {
+	return nil, errors.New("not implemented")
 }

--- a/attest/key_windows.go
+++ b/attest/key_windows.go
@@ -18,6 +18,8 @@
 package attest
 
 import (
+	"crypto"
+	"errors"
 	"fmt"
 
 	"github.com/google/go-tpm/legacy/tpm2"
@@ -109,6 +111,10 @@ func (k *windowsKey12) attestationParameters() AttestationParameters {
 }
 func (k *windowsKey12) certify(tb tpmBase, handle interface{}) (*CertificationParameters, error) {
 	return nil, fmt.Errorf("not implemented")
+}
+
+func (k *windowsKey12) sign(tb tpmBase, digest []byte, pub crypto.PublicKey, opts crypto.SignerOpts, validation any) ([]byte, error) {
+	return nil, errors.New("not implemented")
 }
 
 // windowsKey20 represents a key bound to a TPM 2.0.
@@ -211,4 +217,8 @@ func (k *windowsKey20) certify(tb tpmBase, handle interface{}) (*CertificationPa
 		Hash: tpm2.AlgSHA1, // PCP-created AK uses SHA1
 	}
 	return certify(tpm, hnd, akHnd, scheme)
+}
+
+func (k *windowsKey20) sign(tb tpmBase, digest []byte, pub crypto.PublicKey, opts crypto.SignerOpts, validation any) ([]byte, error) {
+	return nil, errors.New("not implemented")
 }

--- a/attest/tpm.go
+++ b/attest/tpm.go
@@ -16,6 +16,7 @@ package attest
 
 import (
 	"bytes"
+	"crypto"
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
@@ -350,6 +351,7 @@ type tpmBase interface {
 	newKey(ak *AK, opts *KeyConfig) (*Key, error)
 	pcrs(alg HashAlg) ([]PCR, error)
 	measurementLog() ([]byte, error)
+	hash(alg crypto.Hash, data []byte) ([]byte, any, error)
 }
 
 // TPM interfaces with a TPM device on the system.

--- a/attest/tpm12_linux.go
+++ b/attest/tpm12_linux.go
@@ -21,6 +21,7 @@ import (
 	"crypto"
 	"crypto/x509"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"os"
 
@@ -182,4 +183,12 @@ func (t *trousersTPM) pcrs(alg HashAlg) ([]PCR, error) {
 
 func (t *trousersTPM) measurementLog() ([]byte, error) {
 	return os.ReadFile("/sys/kernel/security/tpm0/binary_bios_measurements")
+}
+
+func (t *trousersTPM) sign(tb tpmBase, digest []byte, pub crypto.PublicKey, opts crypto.SignerOpts, validation any) ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (t *trousersTPM) hash(hashAlg crypto.Hash, data []byte) ([]byte, any, error) {
+	return nil, nil, errors.New("not implemented")
 }

--- a/attest/tpm_windows.go
+++ b/attest/tpm_windows.go
@@ -19,6 +19,7 @@ package attest
 
 import (
 	"bytes"
+	"crypto"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -432,4 +433,12 @@ func (t *windowsTPM) measurementLog() ([]byte, error) {
 		return nil, err
 	}
 	return logBuffer, nil
+}
+
+func (t *windowsTPM) sign(tb tpmBase, digest []byte, pub crypto.PublicKey, opts crypto.SignerOpts, validation any) ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (t *windowsTPM) hash(hashAlg crypto.Hash, data []byte) ([]byte, any, error) {
+	return nil, nil, errors.New("not implemented")
 }


### PR DESCRIPTION
Restricted TPM keys, such as AKs, are usually used to sign objects generated within the TPM, such as quotes. However, they can also be used for signing data that was not generated within the TPM, if the data does not start with TPM_GENERATED_VALUE. This requires hashing the data to-be-signed by the TPM and retrieving a validation ticket together with the digest from the TPM. 

It can be useful, e.g., to generate a self-signed Certificate Signing Request for the AK and then retrieve AK certificates from CAs (which are able to perform credential activation) via standard protocols such as Enrollment over Secure Transport (EST). EST mandates that the CSR is self-signed with the corresponding private key (RFC 7030, Section 4.2.1), so this is imho the only possibility to be EST compliant. 

This pull request therefore adds a sign() method to the AK interface for signing arbitrary objects. Furthermore, it adds a hash() method to the TPM interface, as the data to-be-signed by a restricted key must be hashed within the TPM to retrieve a TPM validation ticket. The existing internal sign() method of the wrappedKey20 implementation was extended with a validation ticket parameter to be able to prove that the data was hashed within the TPM. 

Note: currently, I only implemented this additional functionality for the Linux TPM2.0. The TPM1.2 and Windows TPM throw a "not implemented" error if the new methods are called.