### PR TITLE
ci: don't install OpenSSL 1.1 on macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,10 +53,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
       # See https://github.com/google/go-tpm-tools#macos-dev
-    - name: Install openssl
-      run: brew install openssl@1.1
-    - name: Link openssl
-      run: sudo ln -s $(brew --prefix openssl@1.1)/include/openssl /usr/local/include
     - name: Test
       run: C_INCLUDE_PATH="$(brew --prefix openssl@1.1)/include" LIBRARY_PATH="$(brew --prefix openssl@1.1)/lib" go test ./...
   test-windows:


### PR DESCRIPTION
GitHub actions runner macos-13 version 20230801.2 appears to include this by default, causing a link failure.

https://github.com/actions/runner-images/commit/da18545f2f92c7f0231f738634544006514fd702