### PR TITLE
Don't drop leading zeroes when performing generic ecdsa signing

### DIFF
--- a/attest/wrapped_tpm20.go
+++ b/attest/wrapped_tpm20.go
@@ -623,7 +623,9 @@ func signECDSA(rw io.ReadWriter, key tpmutil.Handle, digest []byte, curve ellipt
 	if excess > 0 {
 		ret.Rsh(ret, uint(excess))
 	}
-	digest = ret.Bytes()
+	// call ret.FillBytes() here instead of ret.Bytes() to preserve leading zeroes
+	// that may have been dropped when converting the digest to an integer
+	digest = ret.FillBytes(digest)
 
 	sig, err := tpm2.Sign(rw, key, "", digest, nil, nil)
 	if err != nil {


### PR DESCRIPTION
As @mjg59 pointed out in [#298](https://github.com/google/go-attestation/pull/298#issuecomment-1802877908), this implementation breaks signing when the digest leads with a zero byte. 

To fix this, call ret.FillBytes() instead of ret.Bytes() to preserve leading zeroes that may have been dropped when converting the digest to an integer.