### PR TITLE
Adjust MarshalSubjectAltName to allow SANs to be critical

### DIFF
--- a/x509/x509ext.go
+++ b/x509/x509ext.go
@@ -149,8 +149,9 @@ func forEachSAN(extension []byte, callback func(ext asn1.RawValue) error) error 
 	return nil
 }
 
-// MarshalSubjectAltName converts a SubjectAltName struct into a pkix.Extension.
-func MarshalSubjectAltName(san *SubjectAltName) (pkix.Extension, error) {
+// MarshalSubjectAltName converts a SubjectAltName struct into a pkix.Extension,
+// allowing callers to specify if the extension is critical.
+func MarshalSubjectAltName(san *SubjectAltName, critical bool) (pkix.Extension, error) {
 	var generalNames []asn1.RawValue
 	for _, permID := range san.PermanentIdentifiers {
 		val, err := marshalOtherName(oidPermanentIdentifier, permID)
@@ -171,7 +172,8 @@ func MarshalSubjectAltName(san *SubjectAltName) (pkix.Extension, error) {
 		return pkix.Extension{}, err
 	}
 	return pkix.Extension{
-		Id:    oid.SubjectAltName,
-		Value: val,
+		Id:       oid.SubjectAltName,
+		Critical: critical,
+		Value:    val,
 	}, nil
 }


### PR DESCRIPTION
For both AKs and EKs the Subject Alt Name extension may be critical, or non-critical, based on the presence of the subject field.

So we need to expose control over this criticality to the caller, as detailed more in #366 .

This PR adds a new method MarshalSubjectAltNameWithCriticality that accepts a bool to control the criticality. The existing method (MarshalSubjectAltName) that specifies the extension non-critical is left untouched to maintain compatibility.