### PR TITLE
Support ECC AKs on Linux

### DIFF
--- a/attest/attest.go
+++ b/attest/attest.go
@@ -194,6 +194,9 @@ type AKConfig struct {
 	// If nil, the default SRK (i.e. RSA with handle 0x81000001) is assumed.
 	// Supported only by TPM 2.0 on Linux.
 	Parent *ParentKeyConfig
+
+	// If not specified, the default algorithm (RSA) is assumed.
+	Algorithm Algorithm
 }
 
 // EncryptedCredential represents encrypted parameters which must be activated

--- a/attest/attest_test.go
+++ b/attest/attest_test.go
@@ -83,38 +83,62 @@ func TestAKCreateAndLoad(t *testing.T) {
 	if !*testLocal {
 		t.SkipNow()
 	}
-	tpm, err := OpenTPM(nil)
-	if err != nil {
-		t.Fatalf("OpenTPM() failed: %v", err)
-	}
-	defer tpm.Close()
+	for _, test := range []struct {
+		name string
+		opts *AKConfig
+	}{
+		{
+			name: "NoConfig",
+			opts: nil,
+		},
+		{
+			name: "EmptyConfig",
+			opts: &AKConfig{},
+		},
+		{
+			name: "RSA",
+			opts: &AKConfig{Algorithm: RSA},
+		},
+		{
+			name: "ECDSA",
+			opts: &AKConfig{Algorithm: ECDSA},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tpm, err := OpenTPM(nil)
+			if err != nil {
+				t.Fatalf("OpenTPM() failed: %v", err)
+			}
+			defer tpm.Close()
 
-	ak, err := tpm.NewAK(nil)
-	if err != nil {
-		t.Fatalf("NewAK() failed: %v", err)
-	}
+			ak, err := tpm.NewAK(test.opts)
+			if err != nil {
+				t.Fatalf("NewAK() failed: %v", err)
+			}
 
-	enc, err := ak.Marshal()
-	if err != nil {
-		ak.Close(tpm)
-		t.Fatalf("ak.Marshal() failed: %v", err)
-	}
-	if err := ak.Close(tpm); err != nil {
-		t.Fatalf("ak.Close() failed: %v", err)
-	}
+			enc, err := ak.Marshal()
+			if err != nil {
+				ak.Close(tpm)
+				t.Fatalf("ak.Marshal() failed: %v", err)
+			}
+			if err := ak.Close(tpm); err != nil {
+				t.Fatalf("ak.Close() failed: %v", err)
+			}
 
-	loaded, err := tpm.LoadAK(enc)
-	if err != nil {
-		t.Fatalf("LoadKey() failed: %v", err)
-	}
-	defer loaded.Close(tpm)
+			loaded, err := tpm.LoadAK(enc)
+			if err != nil {
+				t.Fatalf("LoadAK() failed: %v", err)
+			}
+			defer loaded.Close(tpm)
 
-	k1, k2 := ak.ak.(*wrappedKey20), loaded.ak.(*wrappedKey20)
+			k1, k2 := ak.ak.(*wrappedKey20), loaded.ak.(*wrappedKey20)
 
-	if !bytes.Equal(k1.public, k2.public) {
-		t.Error("Original & loaded AK public blobs did not match.")
-		t.Logf("Original = %v", k1.public)
-		t.Logf("Loaded   = %v", k2.public)
+			if !bytes.Equal(k1.public, k2.public) {
+				t.Error("Original & loaded AK public blobs did not match.")
+				t.Logf("Original = %v", k1.public)
+				t.Logf("Loaded   = %v", k2.public)
+			}
+		})
 	}
 }
 

--- a/attest/tpm.go
+++ b/attest/tpm.go
@@ -48,7 +48,7 @@ const (
 )
 
 var (
-	akTemplate = tpm2.Public{
+	akTemplateRSA = tpm2.Public{
 		Type:       tpm2.AlgRSA,
 		NameAlg:    tpm2.AlgSHA256,
 		Attributes: tpm2.FlagSignerDefault | tpm2.FlagNoDA,
@@ -58,6 +58,22 @@ var (
 				Hash: tpm2.AlgSHA256,
 			},
 			KeyBits: 2048,
+		},
+	}
+	akTemplateECC = tpm2.Public{
+		Type:       tpm2.AlgECC,
+		NameAlg:    tpm2.AlgSHA256,
+		Attributes: tpm2.FlagSignerDefault | tpm2.FlagNoDA,
+		ECCParameters: &tpm2.ECCParams{
+			Sign: &tpm2.SigScheme{
+				Alg:  tpm2.AlgECDSA,
+				Hash: tpm2.AlgSHA256,
+			},
+			CurveID: tpm2.CurveNISTP256,
+			Point: tpm2.ECPoint{
+				XRaw: make([]byte, 32),
+				YRaw: make([]byte, 32),
+			},
 		},
 	}
 	defaultRSASRKTemplate = tpm2.Public{


### PR DESCRIPTION
The library supports only RSA Attestation Keys. With this change, users would be able to use ECC Attestation Keys as well, both (1) when creating a new Attestation Key and (2) when creating an Application Key and using the Attestation Key to verify the creation.

Fixes https://github.com/google/go-attestation/issues/386

(This is a recreation of #393, which I destroyed with a force push and now cannot repair since my ability to push to the branch were lost when the PR was closed)