### PR TITLE
attest: Support "qualifyingData" when creating a new key.

### DIFF
--- a/attest/application_key.go
+++ b/attest/application_key.go
@@ -76,6 +76,10 @@ type KeyConfig struct {
 	// If nil, the default SRK (i.e. RSA with handle 0x81000001) is assumed.
 	// Supported only by TPM 2.0 on Linux.
 	Parent *ParentKeyConfig
+	// QualifyingData is an optional data that will be included into
+	// a TPM-generated signature of the minted key.
+	// It may contain any data chosen by the caller.
+	QualifyingData []byte
 }
 
 // defaultConfig is used when no other configuration is specified.

--- a/attest/application_key_test.go
+++ b/attest/application_key_test.go
@@ -100,6 +100,22 @@ func testKeyCreateAndLoad(t *testing.T, tpm *TPM) {
 				Size:      2048,
 			},
 		},
+		{
+			name: "QualifyingData-RSA",
+			opts: &KeyConfig{
+				Algorithm:      RSA,
+				Size:           2048,
+				QualifyingData: []byte("qualifying data"),
+			},
+		},
+		{
+			name: "QualifyingData-ECDSA",
+			opts: &KeyConfig{
+				Algorithm:      ECDSA,
+				Size:           256,
+				QualifyingData: []byte("qualifying data"),
+			},
+		},		
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			sk, err := tpm.NewKey(ak, test.opts)

--- a/attest/attest.go
+++ b/attest/attest.go
@@ -117,7 +117,7 @@ type ak interface {
 	activateCredential(tpm tpmBase, in EncryptedCredential, ek *EK) ([]byte, error)
 	quote(t tpmBase, nonce []byte, alg HashAlg, selectedPCRs []int) (*Quote, error)
 	attestationParameters() AttestationParameters
-	certify(tb tpmBase, handle interface{}) (*CertificationParameters, error)
+	certify(tb tpmBase, handle interface{}, opts CertifyOpts) (*CertificationParameters, error)
 }
 
 // AK represents a key which can be used for attestation.
@@ -185,7 +185,7 @@ func (k *AK) AttestationParameters() AttestationParameters {
 // key. Depending on the actual instantiation it can accept different handle
 // types (e.g., tpmutil.Handle on Linux or uintptr on Windows).
 func (k *AK) Certify(tpm *TPM, handle interface{}) (*CertificationParameters, error) {
-	return k.ak.certify(tpm.tpm, handle)
+	return k.ak.certify(tpm.tpm, handle, CertifyOpts{})
 }
 
 // AKConfig encapsulates parameters for minting keys.

--- a/attest/key_linux.go
+++ b/attest/key_linux.go
@@ -96,6 +96,6 @@ func (k *trousersKey12) attestationParameters() AttestationParameters {
 	}
 }
 
-func (k *trousersKey12) certify(tb tpmBase, handle interface{}) (*CertificationParameters, error) {
+func (k *trousersKey12) certify(tb tpmBase, handle interface{}, _ CertifyOpts) (*CertificationParameters, error) {
 	return nil, fmt.Errorf("not implemented")
 }

--- a/attest/key_windows.go
+++ b/attest/key_windows.go
@@ -107,7 +107,7 @@ func (k *windowsKey12) attestationParameters() AttestationParameters {
 		Public: k.public,
 	}
 }
-func (k *windowsKey12) certify(tb tpmBase, handle interface{}) (*CertificationParameters, error) {
+func (k *windowsKey12) certify(tb tpmBase, handle interface{}, _ CertifyOpts) (*CertificationParameters, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
@@ -185,7 +185,7 @@ func (k *windowsKey20) attestationParameters() AttestationParameters {
 	}
 }
 
-func (k *windowsKey20) certify(tb tpmBase, handle interface{}) (*CertificationParameters, error) {
+func (k *windowsKey20) certify(tb tpmBase, handle interface{}, _ CertifyOpts) (*CertificationParameters, error) {
 	t, ok := tb.(*windowsTPM)
 	if !ok {
 		return nil, fmt.Errorf("expected *windowsTPM, got %T", tb)

--- a/attest/wrapped_tpm20.go
+++ b/attest/wrapped_tpm20.go
@@ -302,7 +302,8 @@ func (t *wrappedTPM20) newKey(ak *AK, opts *KeyConfig) (*Key, error) {
 	}()
 
 	// Certify application key by AK
-	cp, err := k.certify(t, keyHandle)
+	certifyOpts := CertifyOpts{QualifyingData: opts.QualifyingData}
+	cp, err := k.certify(t, keyHandle, certifyOpts)
 	if err != nil {
 		return nil, fmt.Errorf("ak.Certify() failed: %v", err)
 	}
@@ -587,7 +588,7 @@ func sigSchemeFromPublicKey(pub []byte) (tpm2.SigScheme, error) {
 	}
 }
 
-func (k *wrappedKey20) certify(tb tpmBase, handle interface{}) (*CertificationParameters, error) {
+func (k *wrappedKey20) certify(tb tpmBase, handle interface{}, opts CertifyOpts) (*CertificationParameters, error) {
 	t, ok := tb.(*wrappedTPM20)
 	if !ok {
 		return nil, fmt.Errorf("expected *wrappedTPM20, got %T", tb)
@@ -600,7 +601,7 @@ func (k *wrappedKey20) certify(tb tpmBase, handle interface{}) (*CertificationPa
 	if err != nil {
 		return nil, fmt.Errorf("get signature scheme: %v", err)
 	}
-	return certify(t.rwc, hnd, k.hnd, scheme)
+	return certify(t.rwc, hnd, k.hnd, opts.QualifyingData, scheme)
 }
 
 func (k *wrappedKey20) quote(tb tpmBase, nonce []byte, alg HashAlg, selectedPCRs []int) (*Quote, error) {


### PR DESCRIPTION
This change will allow users to pass "qualifyingData" (any user supplied data) to tpm.NewKey(). The qualifying data will be passed to TPM2_Certify command that will be called for the newly minted key.

Fixes #396 