### PR TITLE
attest: Support "qualifyingData" when creating a new key.

### DIFF
--- a/attest/application_key.go
+++ b/attest/application_key.go
@@ -76,6 +76,10 @@ type KeyConfig struct {
 	// If nil, the default SRK (i.e. RSA with handle 0x81000001) is assumed.
 	// Supported only by TPM 2.0 on Linux.
 	Parent *ParentKeyConfig
+	// QualifyingData is an optional data that will be included into
+	// a TPM-generated signature of the minted key.
+	// It may contain any data chosen by the caller.
+	QualifyingData []byte
 }
 
 // defaultConfig is used when no other configuration is specified.

--- a/attest/application_key_test.go
+++ b/attest/application_key_test.go
@@ -100,6 +100,22 @@ func testKeyCreateAndLoad(t *testing.T, tpm *TPM) {
 				Size:      2048,
 			},
 		},
+		{
+			name: "QualifyingData-RSA",
+			opts: &KeyConfig{
+				Algorithm:      RSA,
+				Size:           2048,
+				QualifyingData: []byte("qualifying data"),
+			},
+		},
+		{
+			name: "QualifyingData-ECDSA",
+			opts: &KeyConfig{
+				Algorithm:      ECDSA,
+				Size:           256,
+				QualifyingData: []byte("qualifying data"),
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			sk, err := tpm.NewKey(ak, test.opts)

--- a/attest/attest.go
+++ b/attest/attest.go
@@ -117,7 +117,7 @@ type ak interface {
 	activateCredential(tpm tpmBase, in EncryptedCredential, ek *EK) ([]byte, error)
 	quote(t tpmBase, nonce []byte, alg HashAlg, selectedPCRs []int) (*Quote, error)
 	attestationParameters() AttestationParameters
-	certify(tb tpmBase, handle interface{}) (*CertificationParameters, error)
+	certify(tb tpmBase, handle interface{}, opts CertifyOpts) (*CertificationParameters, error)
 }
 
 // AK represents a key which can be used for attestation.
@@ -185,7 +185,7 @@ func (k *AK) AttestationParameters() AttestationParameters {
 // key. Depending on the actual instantiation it can accept different handle
 // types (e.g., tpmutil.Handle on Linux or uintptr on Windows).
 func (k *AK) Certify(tpm *TPM, handle interface{}) (*CertificationParameters, error) {
-	return k.ak.certify(tpm.tpm, handle)
+	return k.ak.certify(tpm.tpm, handle, CertifyOpts{})
 }
 
 // AKConfig encapsulates parameters for minting keys.

--- a/attest/certification_test.go
+++ b/attest/certification_test.go
@@ -24,6 +24,7 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
+	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -224,6 +225,15 @@ func TestTPM20KeyCertificationECC(t *testing.T) {
 	testKeyCertification(t, tpm, ECDSA)
 }
 
+func extraData(t *testing.T, p CertificationParameters) []byte {
+	t.Helper()
+	ad, err := tpm2.DecodeAttestationData(p.CreateAttestation)
+	if err != nil {
+		t.Fatalf("failed to decode attestation data: %v", err)
+	}
+	return ad.ExtraData
+}
+
 func testKeyCertification(t *testing.T, tpm *TPM, akAlg Algorithm) {
 	ak, err := tpm.NewAK(&AKConfig{Algorithm: akAlg})
 	if err != nil {
@@ -247,9 +257,10 @@ func testKeyCertification(t *testing.T, tpm *TPM, akAlg Algorithm) {
 		Hash:   hash,
 	}
 	for _, test := range []struct {
-		name string
-		opts *KeyConfig
-		err  error
+		name          string
+		opts          *KeyConfig
+		wantExtraData []byte
+		err           error
 	}{
 		{
 			name: "default",
@@ -296,6 +307,26 @@ func testKeyCertification(t *testing.T, tpm *TPM, akAlg Algorithm) {
 			},
 			err: nil,
 		},
+		{
+			name: "QualifyingData-RSA",
+			opts: &KeyConfig{
+				Algorithm:      RSA,
+				Size:           2048,
+				QualifyingData: []byte("qualifying data"),
+			},
+			wantExtraData: []byte("qualifying data"),
+			err:           nil,
+		},
+		{
+			name: "QualifyingData-ECDSA",
+			opts: &KeyConfig{
+				Algorithm:      ECDSA,
+				Size:           384,
+				QualifyingData: []byte("qualifying data"),
+			},
+			wantExtraData: []byte("qualifying data"),
+			err:           nil,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			sk, err := tpm.NewKey(ak, test.opts)
@@ -304,6 +335,9 @@ func testKeyCertification(t *testing.T, tpm *TPM, akAlg Algorithm) {
 			}
 			defer sk.Close()
 			p := sk.CertificationParameters()
+			if gotExtraData, wantExtraData := extraData(t, p), test.wantExtraData; !slices.Equal(gotExtraData, wantExtraData) {
+				t.Errorf("ExtraData got = %v, want = %v", gotExtraData, wantExtraData)
+			}
 			err = p.Verify(verifyOpts)
 			if test.err == nil && err == nil {
 				return

--- a/attest/key_linux.go
+++ b/attest/key_linux.go
@@ -96,6 +96,6 @@ func (k *trousersKey12) attestationParameters() AttestationParameters {
 	}
 }
 
-func (k *trousersKey12) certify(tb tpmBase, handle interface{}) (*CertificationParameters, error) {
+func (k *trousersKey12) certify(tb tpmBase, handle interface{}, _ CertifyOpts) (*CertificationParameters, error) {
 	return nil, fmt.Errorf("not implemented")
 }

--- a/attest/key_windows.go
+++ b/attest/key_windows.go
@@ -107,7 +107,7 @@ func (k *windowsKey12) attestationParameters() AttestationParameters {
 		Public: k.public,
 	}
 }
-func (k *windowsKey12) certify(tb tpmBase, handle interface{}) (*CertificationParameters, error) {
+func (k *windowsKey12) certify(tb tpmBase, handle interface{}, _ CertifyOpts) (*CertificationParameters, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
@@ -185,7 +185,7 @@ func (k *windowsKey20) attestationParameters() AttestationParameters {
 	}
 }
 
-func (k *windowsKey20) certify(tb tpmBase, handle interface{}) (*CertificationParameters, error) {
+func (k *windowsKey20) certify(tb tpmBase, handle interface{}, _ CertifyOpts) (*CertificationParameters, error) {
 	t, ok := tb.(*windowsTPM)
 	if !ok {
 		return nil, fmt.Errorf("expected *windowsTPM, got %T", tb)
@@ -210,5 +210,5 @@ func (k *windowsKey20) certify(tb tpmBase, handle interface{}) (*CertificationPa
 		Alg:  tpm2.AlgRSASSA,
 		Hash: tpm2.AlgSHA1, // PCP-created AK uses SHA1
 	}
-	return certify(tpm, hnd, akHnd, scheme)
+	return certify(tpm, hnd, akHnd, nil, scheme)
 }

--- a/attest/wrapped_tpm20.go
+++ b/attest/wrapped_tpm20.go
@@ -302,7 +302,8 @@ func (t *wrappedTPM20) newKey(ak *AK, opts *KeyConfig) (*Key, error) {
 	}()
 
 	// Certify application key by AK
-	cp, err := k.certify(t, keyHandle)
+	certifyOpts := CertifyOpts{QualifyingData: opts.QualifyingData}
+	cp, err := k.certify(t, keyHandle, certifyOpts)
 	if err != nil {
 		return nil, fmt.Errorf("ak.Certify() failed: %v", err)
 	}
@@ -587,7 +588,7 @@ func sigSchemeFromPublicKey(pub []byte) (tpm2.SigScheme, error) {
 	}
 }
 
-func (k *wrappedKey20) certify(tb tpmBase, handle interface{}) (*CertificationParameters, error) {
+func (k *wrappedKey20) certify(tb tpmBase, handle interface{}, opts CertifyOpts) (*CertificationParameters, error) {
 	t, ok := tb.(*wrappedTPM20)
 	if !ok {
 		return nil, fmt.Errorf("expected *wrappedTPM20, got %T", tb)
@@ -600,7 +601,7 @@ func (k *wrappedKey20) certify(tb tpmBase, handle interface{}) (*CertificationPa
 	if err != nil {
 		return nil, fmt.Errorf("get signature scheme: %v", err)
 	}
-	return certify(t.rwc, hnd, k.hnd, scheme)
+	return certify(t.rwc, hnd, k.hnd, opts.QualifyingData, scheme)
 }
 
 func (k *wrappedKey20) quote(tb tpmBase, nonce []byte, alg HashAlg, selectedPCRs []int) (*Quote, error) {


### PR DESCRIPTION
This change will allow users to pass "qualifyingData" (any user supplied data) to tpm.NewKey(). The qualifying data will be passed to TPM2_Certify command that will be called for the newly minted key.

Fixes https://github.com/google/go-attestation/issues/396