### PR TITLE
TPM.PCRBanks() should ignore empty PCR banks.

### DIFF
--- a/attest/tpm.go
+++ b/attest/tpm.go
@@ -328,6 +328,10 @@ func pcrbanks(tpm io.ReadWriter) ([]HashAlg, error) {
 			continue
 		}
 
+		if len(pcrb.PCRs) == 0 {
+			// ignore empty PCR banks.
+			continue
+		}
 		hAlgs = append(hAlgs, HashAlg(pcrb.Hash))
 	}
 


### PR DESCRIPTION
Empty PCR banks are allowed by the TPC spec. But they are no use for the library. If TPM.PCRBanks() were to return an algorithm for which the TPM has zero PCRs, any following attempt to use this algorithm (i.e. in TPM.PCRs() or TPM.AttestPlatform()) would result in an error anyway. It may be better to omit those algorithms in the first place.