### PR TITLE
Support ECDSA based AK's on Windows

### DIFF
--- a/attest/activation_test.go
+++ b/attest/activation_test.go
@@ -67,3 +67,33 @@ func TestActivationTPM20(t *testing.T) {
 		t.Fatalf("secret = %v, want %v", got, want)
 	}
 }
+
+func TestECCActivationTPM20(t *testing.T) {
+	priv := ekCertSigner(t)
+	rand := rand.New(rand.NewSource(123456))
+
+	// These parameters represent an ECC P256 AK generated on a real-world,
+	// Google vTPM.
+	params := ActivationParameters{
+		TPMVersion: TPMVersion20,
+		AK: AttestationParameters{
+			Public:            decodeBase64("ACMACwAFBHIAIJ3/y/NsODrmmfuYaNxty4nXFTiEvigDkiwSQVi/rSKuABAAGAAEAAMAEAAgydcfFWW6O7PjW9vnOE4IDx3545TxylD1iVHP8MIFI78AIJuD/QM9EbqM+3SEl7PgiXlWV1NhmvnmE2AHiEfI/hUn", t),
+			CreateData:        decodeBase64("AAAAAAAg47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFUBAAsAIgALLEyPGewwEIKqPNw9Lx7QXsfp0MsOZFt4EzHFT4tSXekAIgALf7O+OxqTNzTuIhi1YGQoulPZoyxsNKHpBgT4dHqT3+UAAA==", t),
+			CreateAttestation: decodeBase64("/1RDR4AaACIAC8Uqr5OAkfcyLJ2gLU2oSvIoPi8XdoLHGdpS5h/JJz8aAAAAAAAEXezQqarG49k44bBnAUna81DZr1xhACIAC3AoqIzDrusUtdH3uAwqbqUrybtu35H1XPQDyLBHVGF+ACCKEKpwL1LFbw/IG+vtJ6CtXHIYBhVWyrkAqYLkHleYMw==", t),
+			CreateSignature:   decodeBase64("ABgABAAgbTEBcZvjb9uEEYZCiSqPh/XO0BZQS+egnJ8WKtpSbmkAIDNgvF9iyiOCvd5480hOCzjRj7GP3YZ3XqjEVvN3Q3Ca", t),
+		},
+		EK: &rsa.PublicKey{
+			E: priv.E,
+			N: priv.N,
+		},
+		Rand: rand,
+	}
+
+	secret, _, err := params.Generate()
+	if err != nil {
+		t.Fatalf("Generate() returned err: %v", err)
+	}
+	if got, want := secret, decodeBase64("0vhS7HtORX9uf/iyQ8Sf9WkpJuoJ1olCfTjSZuyNNxY=", t); !bytes.Equal(got, want) {
+		t.Fatalf("secret = %v, want %v", got, want)
+	}
+}

--- a/attest/application_key.go
+++ b/attest/application_key.go
@@ -63,6 +63,13 @@ type Algorithm string
 const (
 	ECDSA Algorithm = "ECDSA"
 	RSA   Algorithm = "RSA"
+
+	// Windows specific ECDSA CNG algorithm identifiers.
+	// NOTE: Using ECDSA will default to ECDSA_P256.
+	// Ref: https://learn.microsoft.com/en-us/windows/win32/SecCNG/cng-algorithm-identifiers
+	ECDSA_P256 Algorithm = "ECDSA_P256"
+	ECDSA_P384 Algorithm = "ECDSA_P384"
+	ECDSA_P521 Algorithm = "ECDSA_P521"
 )
 
 // KeyConfig encapsulates parameters for minting keys.
@@ -86,6 +93,24 @@ type KeyConfig struct {
 var defaultConfig = &KeyConfig{
 	Algorithm: ECDSA,
 	Size:      256,
+}
+
+// Size returns the bit size associated with an algorithm.
+func (a Algorithm) Size() int {
+	switch a {
+	case RSA:
+		return 2048
+	case ECDSA:
+		return 256
+	case ECDSA_P256:
+		return 256
+	case ECDSA_P384:
+		return 384
+	case ECDSA_P521:
+		return 521
+	default:
+		return 0
+	}
 }
 
 // Public returns the public key corresponding to the private key.

--- a/attest/attest.go
+++ b/attest/attest.go
@@ -190,6 +190,8 @@ func (k *AK) Certify(tpm *TPM, handle interface{}) (*CertificationParameters, er
 
 // AKConfig encapsulates parameters for minting keys.
 type AKConfig struct {
+	// Optionally set unique name for AK on Windows.
+	Name string
 	// Parent describes the Storage Root Key that will be used as a parent.
 	// If nil, the default SRK (i.e. RSA with handle 0x81000001) is assumed.
 	// Supported only by TPM 2.0 on Linux.

--- a/attest/attest_test.go
+++ b/attest/attest_test.go
@@ -131,12 +131,13 @@ func TestAKCreateAndLoad(t *testing.T) {
 			}
 			defer loaded.Close(tpm)
 
-			k1, k2 := ak.ak.(*wrappedKey20), loaded.ak.(*wrappedKey20)
+			k1 := ak.ak.attestationParameters()
+			k2 := loaded.ak.attestationParameters()
 
-			if !bytes.Equal(k1.public, k2.public) {
+			if !bytes.Equal(k1.Public, k2.Public) {
 				t.Error("Original & loaded AK public blobs did not match.")
-				t.Logf("Original = %v", k1.public)
-				t.Logf("Loaded   = %v", k2.public)
+				t.Logf("Original = %v", k1.Public)
+				t.Logf("Loaded   = %v", k2.Public)
 			}
 		})
 	}


### PR DESCRIPTION
Currently, ECDSA AK support was partially added in the following commits for Linux platform:
- https://github.com/google/go-attestation/commit/1b202b12e80969eb8c5933a9197c16f5f7529d37
- https://github.com/google/go-attestation/commit/c7aee80c5d760a084adf51055b748d04a3187818

This PR builds on the above commits and adds the following functionality:
1. Ability to generate encrypted credential blob for activating ECDSA based AK's.
2. Support minting P256, P384 & P521 curve based ECDSA AK's on Windows platform.
3. Add ability to use custom names for AK's on Windows platform.
