### PR TITLE
x509ext.ParseSubjectAltName() rejects unknown otherName type ids

### DIFF
--- a/x509/x509ext.go
+++ b/x509/x509ext.go
@@ -89,6 +89,8 @@ func ParseSubjectAltName(ext pkix.Extension) (*SubjectAltName, error) {
 				return nil, fmt.Errorf("parsePermanentIdentifier: %v", err)
 			}
 			out.PermanentIdentifiers = append(out.PermanentIdentifiers, permID)
+		} else {
+			return nil, fmt.Errorf("expected type id %v, got %v", oidPermanentIdentifier, otherName.TypeID)
 		}
 	}
 	return &out, nil


### PR DESCRIPTION
It currently already reject SAN with unknown tags. It should be strict and also reject unknown otherName type ids.