### PR TITLE
Add oid.VerifiedTPM{Fixed,Residency}

### DIFF
--- a/oid/oid.go
+++ b/oid/oid.go
@@ -34,6 +34,8 @@ var (
 	PlatformConfigurationV1    = []int{2, 23, 133, 5, 1, 7, 1}
 	PlatformConfigurationV2    = []int{2, 23, 133, 5, 1, 7, 2}
 	EKCertificate              = []int{2, 23, 133, 8, 1}
+	VerifiedTPMResidency       = []int{2, 23, 133, 11, 1, 1}
+	VerifiedTPMFixed           = []int{2, 23, 133, 11, 1, 2}
 	VerifiedTPMRestricted      = []int{2, 23, 133, 11, 1, 3}
 	EKPermIDSHA256             = []int{2, 23, 133, 12, 1}
 )


### PR DESCRIPTION
We already have VerifiedTPMRestricted from Section 8.2 of [1]. Also add the the other two OIDs there. Go-attestation itself might not use it, but the user of it might need it (e.g. to add a VerifiedTPMResidency policy to an AK cert)

[1] https://trustedcomputinggroup.org/wp-content/uploads/TPM-2p0-Keys-for-Device-Identity-and-Attestation_v1_r12_pub10082021.pdf