### PR TITLE
As per RFC 5755, OtherObjectTypeID is optional

### DIFF
--- a/attributecert/attributecert.go
+++ b/attributecert/attributecert.go
@@ -177,7 +177,7 @@ type userNotice struct {
 // RFC 5755 4.1
 type objectDigestInfo struct {
 	DigestedObjectType asn1.Enumerated
-	OtherObjectTypeID  asn1.ObjectIdentifier
+	OtherObjectTypeID  asn1.ObjectIdentifier `asn1:"optional"`
 	DigestAlgorithm    pkix.AlgorithmIdentifier
 	ObjectDigest       asn1.BitString
 }


### PR DESCRIPTION
This PR makes this field optional

Here is the detail from the RFC 5755 official document

```
RFC 5755              AC Profile for Authorization          January 2010


        ObjectDigestInfo ::= SEQUENCE {
          digestedObjectType  ENUMERATED {
            publicKey            (0),
            publicKeyCert        (1),
            otherObjectTypes     (2) },
          -- otherObjectTypes MUST NOT
          -- be used in this profile
          otherObjectTypeID   OBJECT IDENTIFIER OPTIONAL,
          digestAlgorithm     AlgorithmIdentifier,
          objectDigest        BIT STRING
        }
```