### PR TITLE
Add SignMsg() and Public() to AK

### DIFF
--- a/attest/key_windows.go
+++ b/attest/key_windows.go
@@ -18,6 +18,7 @@
 package attest
 
 import (
+	"crypto"
 	"fmt"
 
 	"github.com/google/go-tpm/legacy/tpm2"
@@ -123,4 +124,8 @@ func (k *windowsKey20) certify(tb tpmBase, handle any, _ CertifyOpts) (*Certific
 		Hash: tpm2.AlgSHA1, // PCP-created AK uses SHA1
 	}
 	return certify(tpm, hnd, akHnd, nil, scheme)
+}
+
+func (k *windowsKey20) signMsg(tb tpmBase, msg []byte, pub crypto.PublicKey, opts crypto.SignerOpts) ([]byte, error) {
+	return nil, fmt.Errorf("not implemented")
 }


### PR DESCRIPTION
Since AK is an restricted signing key, the new `AK.SignMsg()` method will take the original message (instead of a digest). And it will use the TPM to hash the message and get a validation ticket for the final signing.