### PR TITLE
Fix(attributecert): Use int64 for ComponentManufacturerID

### DIFF
--- a/attributecert/attributecert.go
+++ b/attributecert/attributecert.go
@@ -275,7 +275,7 @@ type Component struct {
 	Model            string
 	Serial           string
 	Revision         string
-	ManufacturerID   int
+	ManufacturerID   int64
 	FieldReplaceable bool
 	Addresses        []ComponentAddress
 }
@@ -435,7 +435,7 @@ type ComponentIdentifierV2 struct {
 	ComponentModel           string
 	ComponentSerial          string                `asn1:"optional,utf8,tag:0"`
 	ComponentRevision        string                `asn1:"optional,utf8,tag:1"`
-	ComponentManufacturerID  int                   `asn1:"optional,tag:2"`
+	ComponentManufacturerID  int64                 `asn1:"optional,tag:2"`
 	FieldReplaceable         bool                  `asn1:"optional,tag:3"`
 	ComponentAddresses       []ComponentAddress    `asn1:"optional,tag:4"`
 	ComponentPlatformCert    CertificateIdentifier `asn1:"optional,tag:5"`
@@ -469,7 +469,7 @@ type ComponentIdentifierV1 struct {
 	ComponentModel          string
 	ComponentSerial         string             `asn1:"optional,utf8,tag:0"`
 	ComponentRevision       string             `asn1:"optional,utf8,tag:1"`
-	ComponentManufacturerID int                `asn1:"optional,tag:2"`
+	ComponentManufacturerID int64              `asn1:"optional,tag:2"`
 	FieldReplaceable        bool               `asn1:"optional,tag:3"`
 	ComponentAddresses      []ComponentAddress `asn1:"optional,tag:4"`
 }


### PR DESCRIPTION
The ComponentManufacturerID field in the ComponentIdentifierV1 and ComponentIdentifierV2 structs was an 'int', which is only 32 bits on 32-bit architectures. This caused an "integer too large" error when parsing a certificate with a manufacturer ID that exceeded the maximum value for a 32-bit signed integer.

This change fixes the issue by changing the type of the ComponentManufacturerID field to int64 in the Component, ComponentIdentifierV1, and ComponentIdentifierV2 structs. This ensures that the field has enough range to handle larger integer values on all architectures.

Fixes #439
