### PR TITLE
Add certificate parser to parse x509 Certificate to EK Certificate.

### DIFF
--- a/x509/ekcert.go
+++ b/x509/ekcert.go
@@ -154,7 +154,7 @@ func ToEKCertificate(cert *x509.Certificate) (*EKCertificate, error) {
 			}
 		case ext.Id.Equal(oid.CertificatePolicies):
 			if len(cert.PolicyIdentifiers) == 0 {
-				return nil, errors.New("Certificate Policies should contain at least 1 policy identifier if the extension is present")
+				return nil, errors.New("extension \"Certificate Policies\" should contain at least 1 policy identifier if the extension is present")
 			}
 		case ext.Id.Equal(oidAuthorityInfoAccess):
 			if ext.Critical {
@@ -186,7 +186,7 @@ func ToEKCertificate(cert *x509.Certificate) (*EKCertificate, error) {
 
 	// Authority Key ID must be present and non-empty.
 	if len(cert.AuthorityKeyId) == 0 {
-		return nil, errors.New("Authority Key ID is missing")
+		return nil, errors.New("missing Authority Key ID")
 	}
 
 	// KeyUsage must be set and correctly set for the public key type.

--- a/x509/ekcert_test.go
+++ b/x509/ekcert_test.go
@@ -346,7 +346,7 @@ func TestToEKCertificate_Failures(t *testing.T) {
 			modifyCert: func(t *testing.T, cert *x509.Certificate) {
 				cert.AuthorityKeyId = []byte{}
 			},
-			wantErr: errors.New("Authority Key ID is missing"),
+			wantErr: errors.New("missing Authority Key ID"),
 		},
 		{
 			name: "Authority Key Identifier is critical",
@@ -396,7 +396,7 @@ func TestToEKCertificate_Failures(t *testing.T) {
 				modifyExtension(t, cert, oid.CertificatePolicies, []byte{0x30, 0x00}, true)
 				cert.PolicyIdentifiers = []asn1.ObjectIdentifier{}
 			},
-			wantErr: errors.New("Certificate Policies should contain at least 1 policy identifier if the extension is present"),
+			wantErr: errors.New("extension \"Certificate Policies\" should contain at least 1 policy identifier if the extension is present"),
 		},
 		{
 			name: "AuthorityInfoAccess is critical",


### PR DESCRIPTION
Add certificate parser to parse x509 Certificate to EK Certificate. 
The standard fields are validated by referencing the [TCG EK Credential Profile](https://trustedcomputinggroup.org/wp-content/uploads/TCG-EK-Credential-Profile-for-TPM-Family-2.0-Level-0-Version-2.6_pub.pdf).