### PR TITLE
fix: return error instead of nil when pub.Key() fails in verifyECDSASignature

### DIFF
--- a/attest/activation.go
+++ b/attest/activation.go
@@ -180,7 +180,7 @@ func verifyRSASignature(pub tpm2.Public, p *ActivationParameters) error {
 func verifyECDSASignature(pub tpm2.Public, p *ActivationParameters) error {
 	key, err := pub.Key()
 	if err != nil {
-		return nil
+		return fmt.Errorf("failed to extract ECC public key: %v", err)
 	}
 	pk, ok := key.(*ecdsa.PublicKey)
 	if !ok {


### PR DESCRIPTION
## Summary

`verifyECDSASignature()` in `attest/activation.go` (line 183) returns `nil` (success) when `pub.Key()` fails, silently bypassing all ECDSA signature verification. Malformed ECC key parameters that cause `pub.Key()` to error result in the function treating the verification as successful.

## The Bug

```go
func verifyECDSASignature(pub tpm2.Public, p *ActivationParameters) error {
    key, err := pub.Key()
    if err != nil {
        return nil  // BUG: returns success instead of error
    }
    // ... all ECDSA verification below is skipped ...
}
```

Compare with the RSA counterpart which correctly propagates errors:

```go
func verifyRSASignature(pub tpm2.Public, p *ActivationParameters) error {
    // ...
    signHash, err := pub.RSAParameters.Sign.Hash.Hash()
    if err != nil {
        return err  // CORRECT
    }
```

## The Fix

One-line change — return the error instead of nil:

```diff
  key, err := pub.Key()
  if err != nil {
-     return nil
+     return fmt.Errorf("failed to extract ECC public key: %v", err)
  }
```

## Impact

When `pub.Key()` fails (invalid ECC coordinates, unsupported curve, malformed parameters), the entire ECDSA verification is bypassed. This affects any system using go-attestation for TPM ECC key attestation via `ActivationParameters.Verify()`.