### PR TITLE
attest: return error when ECC public key parsing fails in verifyECDSASignature

### DIFF
--- a/attest/activation.go
+++ b/attest/activation.go
@@ -180,7 +180,7 @@ func verifyRSASignature(pub tpm2.Public, p *ActivationParameters) error {
 func verifyECDSASignature(pub tpm2.Public, p *ActivationParameters) error {
 	key, err := pub.Key()
 	if err != nil {
-		return nil
+		return fmt.Errorf("failed to parse ECC public key: %w", err)
 	}
 	pk, ok := key.(*ecdsa.PublicKey)
 	if !ok {


### PR DESCRIPTION
`verifyECDSASignature` in `attest/activation.go` returns `nil` when
`pub.Key()` fails, silently skipping ECDSA signature verification
for malformed ECC keys. This allows `ActivationParameters.Generate()`
to succeed without validating `CreateSignature`.

This is the same class of issue as CVE-2022-0317 but in the ECC
code path. A malformed ECC TPMT_PUBLIC causes `Key()` to return an
error, which is silently swallowed, so the attestation flow proceeds
without ever checking the AK's creation signature.

The fix returns the error instead of `nil`.