### PR TITLE
Use correct variable in error message for public key type

### DIFF
--- a/attest/certification.go
+++ b/attest/certification.go
@@ -195,7 +195,7 @@ func (p *CertificationParameters) Verify(opts VerifyOpts) error {
 			return fmt.Errorf("could not verify ECC attestation")
 		}
 	default:
-		return fmt.Errorf("unsupported public key type: %T", pub)
+		return fmt.Errorf("unsupported public key type: %T", pk)
 	}
 
 	return nil


### PR DESCRIPTION
Verify error message reports pub (the decoded attested key) instead of the actual unsupported type of the verifying key opts.Public.