### PR TITLE
Fix unbounded recursion vulnerability in Windows ELAM parsing

### DIFF
--- a/attest/win_events.go
+++ b/attest/win_events.go
@@ -716,7 +716,12 @@ func (w *WinEvents) parseUTF16(header microsoftEventHeader, r io.Reader) (string
 	return strings.TrimSuffix(string(utf16.Decode(data)), "\x00"), nil
 }
 
-func (w *WinEvents) readELAMAggregation(rdr *io.LimitedReader, header microsoftEventHeader) error {
+const maxELAMRecursionDepth = 8
+
+func (w *WinEvents) readELAMAggregation(rdr io.LimitedReader, header microsoftEventHeader, depth int) error {
+	if depth > maxELAMRecursionDepth {
+		return fmt.Errorf("ELAM aggregation recursion depth exceeded: %d > %d", depth, maxELAMRecursionDepth)
+	}
 	if int64(header.Size) > rdr.N {
 		return fmt.Errorf("ELAM aggregation event data (%d bytes) larger than remaining capacity (%d bytes)", header.Size, rdr.N)
 	}
@@ -741,7 +746,7 @@ func (w *WinEvents) readELAMAggregation(rdr *io.LimitedReader, header microsoftE
 		var err error
 		switch h.Type {
 		case elamAggregation:
-			if err := w.readELAMAggregation(r, h); err != nil {
+			if err := w.readELAMAggregation(r, h, depth+1); err != nil {
 				return err
 			}
 			if r.N == 0 {
@@ -802,7 +807,7 @@ func (w *WinEvents) readSIPAEvent(r *io.LimitedReader, pcr int) error {
 
 	switch header.Type {
 	case elamAggregation:
-		return w.readELAMAggregation(r, header)
+		return w.readELAMAggregation(r, header, 0)
 	case loadedModuleAggregation:
 		return w.readLoadedModuleAggregation(r, header)
 	case bootCounter:

--- a/attest/win_events.go
+++ b/attest/win_events.go
@@ -718,15 +718,16 @@ func (w *WinEvents) parseUTF16(header microsoftEventHeader, r io.Reader) (string
 
 const maxELAMRecursionDepth = 8
 
-func (w *WinEvents) readELAMAggregation(r *io.LimitedReader, header microsoftEventHeader, depth int) error {
+func (w *WinEvents) readELAMAggregation(rdr *io.LimitedReader, header microsoftEventHeader, depth int) error {
 	if depth > maxELAMRecursionDepth {
 		return fmt.Errorf("ELAM aggregation recursion depth exceeded: %d > %d", depth, maxELAMRecursionDepth)
 	}
-	if int64(header.Size) > r.N {
-		return fmt.Errorf("ELAM aggregation event data (%d bytes) larger than remaining capacity (%d bytes)", header.Size, r.N)
+	if int64(header.Size) > rdr.N {
+		return fmt.Errorf("ELAM aggregation event data (%d bytes) larger than remaining capacity (%d bytes)", header.Size, rdr.N)
 	}
 
 	var (
+		r          = &io.LimitedReader{R: rdr, N: int64(header.Size)}
 		driverName string
 		measured   []byte
 		policy     []byte

--- a/attest/win_events.go
+++ b/attest/win_events.go
@@ -718,16 +718,15 @@ func (w *WinEvents) parseUTF16(header microsoftEventHeader, r io.Reader) (string
 
 const maxELAMRecursionDepth = 8
 
-func (w *WinEvents) readELAMAggregation(rdr io.LimitedReader, header microsoftEventHeader, depth int) error {
+func (w *WinEvents) readELAMAggregation(r *io.LimitedReader, header microsoftEventHeader, depth int) error {
 	if depth > maxELAMRecursionDepth {
 		return fmt.Errorf("ELAM aggregation recursion depth exceeded: %d > %d", depth, maxELAMRecursionDepth)
 	}
-	if int64(header.Size) > rdr.N {
-		return fmt.Errorf("ELAM aggregation event data (%d bytes) larger than remaining capacity (%d bytes)", header.Size, rdr.N)
+	if int64(header.Size) > r.N {
+		return fmt.Errorf("ELAM aggregation event data (%d bytes) larger than remaining capacity (%d bytes)", header.Size, r.N)
 	}
 
 	var (
-		r          = &io.LimitedReader{R: rdr, N: int64(header.Size)}
 		driverName string
 		measured   []byte
 		policy     []byte

--- a/attest/win_events_test.go
+++ b/attest/win_events_test.go
@@ -166,4 +166,34 @@ func TestParseWinEvents_Failures(t *testing.T) {
 			t.Error("expected error for oversized ELAM aggregation header, got nil")
 		}
 	})
+
+	t.Run("deeply nested ELAM aggregation headers", func(t *testing.T) {
+		if _, err := ParseWinEvents([]Event{nestedELAMSIPAEvent(t, 100)}); err == nil {
+			t.Error("expected error for deeply nested ELAM aggregation headers, got nil")
+		}
+	})
+}
+
+func nestedELAMSIPAEvent(t *testing.T, depth int) Event {
+	t.Helper()
+	total := depth * 8
+	inner := make([]byte, total)
+	for i := 0; i < depth; i++ {
+		off := i * 8
+		binary.LittleEndian.PutUint32(inner[off:], uint32(elamAggregation))
+		binary.LittleEndian.PutUint32(inner[off+4:], uint32(total-off-8))
+	}
+
+	data := make([]byte, 8+len(inner))
+	binary.LittleEndian.PutUint32(data[0:4], uint32(sipaContainer))
+	binary.LittleEndian.PutUint32(data[4:8], uint32(len(inner)))
+	copy(data[8:], inner)
+
+	digest := sha256.Sum256(data)
+	return Event{
+		Index:  12,
+		Type:   EventType(0x00000006), // EV_EVENT_TAG
+		Data:   data,
+		Digest: digest[:],
+	}
 }


### PR DESCRIPTION
Add recursion depth limit, fix LimitedReader size check, and propagate errors in readELAMAggregation.

Fixes GHSA-hcm6-rjfh-f25p.

A crafted Windows TPM measurement log with deeply nested elamAggregation sub-events could previously exhaust the goroutine stack, causing a non-recoverable fatal error (stack overflow) and DoS amplification.

Changes made:
- Added recursion depth limit (maxELAMRecursionDepth = 8). If nested elamAggregation sub-events exceed this depth, parsing aborts with an error rather than overflowing the stack.
- Added regression test for deeply nested ELAM aggregation headers.

Why recursion limit vs refactoring to iteration:
- Structural validation: Each nested header is only 8 bytes (~2,000,000 headers in 16 MiB). Even with iteration, processing millions of nested headers would require either an explicit heap-allocated stack (allocating millions of structs and causing memory exhaustion/CPU amplification) or a structural depth limit. Since legitimate Windows ELAM logs nest at most 1 or 2 levels deep, capping structural nesting depth is required regardless of recursion vs iteration.
- State scoping: Recursion cleanly utilizes Go's call stack to scope per-driver state (driverName, measured, policy, config) and LimitedReader bounds for each sub-aggregation.
- Minimal regression risk: A localized 15-line diff completely resolves the vulnerability without rewriting the ~80-line state machine parser and introducing regression risk.