### PR TITLE
Handle errors from readELAMAggregation

### DIFF
--- a/attest/win_events.go
+++ b/attest/win_events.go
@@ -710,7 +710,9 @@ func (w *WinEvents) readELAMAggregation(rdr io.Reader, header microsoftEventHead
 		var err error
 		switch h.Type {
 		case elamAggregation:
-			w.readELAMAggregation(r, h)
+			if err := w.readELAMAggregation(r, h); err != nil {
+				return err
+			}
 			if r.N == 0 {
 				return nil
 			}


### PR DESCRIPTION
The error returned by `w.readELAMAggregation` is now checked and propagated, preventing silent failures.

Discovered in GHSA-hcm6-rjfh-f25p, but this change alone does not fix GHSA-hcm6-rjfh-f25p.