### PR TITLE
Prevent memory exhaustion DoS by limiting make allocations with LimitedReader

### DIFF
--- a/attest/attest-tool/internal/eventlog/secureboot.go
+++ b/attest/attest-tool/internal/eventlog/secureboot.go
@@ -204,28 +204,34 @@ func verifyDigest(digest, data []byte) bool {
 //
 // https://trustedcomputinggroup.org/wp-content/uploads/TCG_PCClient_Specific_Platform_Profile_for_TPM_2p0_1p04_PUBLIC.pdf#page=100
 func parseUEFIVariableData(b, digest []byte) (*uefiVariableData, error) {
-	r := bytes.NewBuffer(b)
+	lr := &io.LimitedReader{R: bytes.NewReader(b), N: int64(len(b))}
 	var hdr struct {
 		ID         efiGUID
 		NameLength uint64
 		DataLength uint64
 	}
-	if err := binaryRead(r, &hdr); err != nil {
+	if err := binaryRead(lr, &hdr); err != nil {
 		return nil, err
 	}
+	if hdr.NameLength > uint64(lr.N)/2 {
+		return nil, fmt.Errorf("requested NameLength (%d uint16s) exceeds message size (%d uint16s)", hdr.NameLength, lr.N/2)
+	}
 	name := make([]uint16, hdr.NameLength)
-	if err := binaryRead(r, &name); err != nil {
+	if err := binaryRead(lr, &name); err != nil {
 		return nil, fmt.Errorf("parsing name: %v", err)
 	}
-	if r.Len() != int(hdr.DataLength) {
-		return nil, fmt.Errorf("remaining bytes %d doesn't match data length %d", r.Len(), hdr.DataLength)
+	if lr.N != int64(hdr.DataLength) {
+		return nil, fmt.Errorf("remaining bytes %d doesn't match data length %d", lr.N, hdr.DataLength)
 	}
-	data := r.Bytes()
+	data := make([]byte, hdr.DataLength)
+	if _, err := io.ReadFull(lr, data); err != nil {
+		return nil, fmt.Errorf("reading data: %v", err)
+	}
 	// TODO(ericchiang): older UEFI firmware (Lenovo Bios version 1.17) logs the
 	// digest of the data, which doesn't encapsulate the ID or name. This lets
 	// attackers alter keys and we should determine if this is an acceptable risk.
 	if !verifyDigest(digest, b) && !verifyDigest(digest, data) {
 		return nil, fmt.Errorf("digest didn't match data")
 	}
-	return &uefiVariableData{id: hdr.ID, name: string(utf16.Decode(name)), data: r.Bytes()}, nil
+	return &uefiVariableData{id: hdr.ID, name: string(utf16.Decode(name)), data: data}, nil
 }

--- a/attest/internal/events.go
+++ b/attest/internal/events.go
@@ -236,13 +236,16 @@ type UEFIVariableData struct {
 // a UEFI variable.
 //
 // https://trustedcomputinggroup.org/wp-content/uploads/TCG_PCClient_Specific_Platform_Profile_for_TPM_2p0_1p04_PUBLIC.pdf#page=100
-func ParseUEFIVariableData(r io.Reader) (ret UEFIVariableData, err error) {
+func ParseUEFIVariableData(r *io.LimitedReader) (ret UEFIVariableData, err error) {
 	err = binary.Read(r, binary.LittleEndian, &ret.Header)
 	if err != nil {
 		return
 	}
 	if ret.Header.UnicodeNameLength > maxNameLen {
 		return UEFIVariableData{}, fmt.Errorf("unicode name too long: %d > %d", ret.Header.UnicodeNameLength, maxNameLen)
+	}
+	if int64(ret.Header.UnicodeNameLength)*2 > r.N {
+		return UEFIVariableData{}, fmt.Errorf("unicode name length (%d bytes) larger than remaining capacity (%d bytes)", ret.Header.UnicodeNameLength*2, r.N)
 	}
 	ret.UnicodeName = make([]uint16, ret.Header.UnicodeNameLength)
 	for i := 0; uint64(i) < ret.Header.UnicodeNameLength; i++ {
@@ -253,6 +256,9 @@ func ParseUEFIVariableData(r io.Reader) (ret UEFIVariableData, err error) {
 	}
 	if ret.Header.VariableDataLength > maxDataLen {
 		return UEFIVariableData{}, fmt.Errorf("variable data too long: %d > %d", ret.Header.VariableDataLength, maxDataLen)
+	}
+	if int64(ret.Header.VariableDataLength) > r.N {
+		return UEFIVariableData{}, fmt.Errorf("variable data length (%d bytes) larger than remaining capacity (%d bytes)", ret.Header.VariableDataLength, r.N)
 	}
 	ret.VariableData = make([]byte, ret.Header.VariableDataLength)
 	_, err = io.ReadFull(r, ret.VariableData)
@@ -526,7 +532,7 @@ type EFIImageLoadHeader struct {
 	DevicePathLen uint64
 }
 
-func parseDevicePathElement(r io.Reader) (EFIDevicePathElement, error) {
+func parseDevicePathElement(r *io.LimitedReader) (EFIDevicePathElement, error) {
 	var (
 		out     EFIDevicePathElement
 		dataLen uint16
@@ -547,6 +553,9 @@ func parseDevicePathElement(r io.Reader) (EFIDevicePathElement, error) {
 	if dataLen < 4 {
 		return EFIDevicePathElement{}, fmt.Errorf("device path data too short: %d < %d", dataLen, 4)
 	}
+	if int64(dataLen-4) > r.N {
+		return EFIDevicePathElement{}, fmt.Errorf("device path element data (%d bytes) larger than remaining capacity (%d bytes)", dataLen-4, r.N)
+	}
 	out.Data = make([]byte, dataLen-4)
 	if err := binary.Read(r, binary.LittleEndian, &out.Data); err != nil {
 		return EFIDevicePathElement{}, fmt.Errorf("reading data: %v", err)
@@ -557,11 +566,11 @@ func parseDevicePathElement(r io.Reader) (EFIDevicePathElement, error) {
 // DevicePath returns the device path elements from the EFI_IMAGE_LOAD_EVENT structure.
 func (h *EFIImageLoad) DevicePath() ([]EFIDevicePathElement, error) {
 	var (
-		r   = bytes.NewReader(h.DevPathData)
+		r   = &io.LimitedReader{R: bytes.NewReader(h.DevPathData), N: int64(len(h.DevPathData))}
 		out []EFIDevicePathElement
 	)
 
-	for r.Len() > 0 {
+	for r.N > 0 {
 		e, err := parseDevicePathElement(r)
 		if err != nil {
 			return nil, err
@@ -579,13 +588,16 @@ func (h *EFIImageLoad) DevicePath() ([]EFIDevicePathElement, error) {
 // ParseEFIImageLoad parses an EFI_IMAGE_LOAD_EVENT structure.
 //
 // https://trustedcomputinggroup.org/wp-content/uploads/TCG_EFI_Platform_1_22_Final_-v15.pdf#page=17
-func ParseEFIImageLoad(r io.Reader) (ret EFIImageLoad, err error) {
+func ParseEFIImageLoad(r *io.LimitedReader) (ret EFIImageLoad, err error) {
 	err = binary.Read(r, binary.LittleEndian, &ret.Header)
 	if err != nil {
 		return
 	}
 	if ret.Header.DevicePathLen > maxNameLen {
 		return EFIImageLoad{}, fmt.Errorf("device path structure too long: %d > %d", ret.Header.DevicePathLen, maxNameLen)
+	}
+	if int64(ret.Header.DevicePathLen) > r.N {
+		return EFIImageLoad{}, fmt.Errorf("device path structure size (%d bytes) larger than remaining capacity (%d bytes)", ret.Header.DevicePathLen, r.N)
 	}
 	ret.DevPathData = make([]byte, ret.Header.DevicePathLen)
 	err = binary.Read(r, binary.LittleEndian, &ret.DevPathData)

--- a/attest/internal/events.go
+++ b/attest/internal/events.go
@@ -236,7 +236,8 @@ type UEFIVariableData struct {
 // a UEFI variable.
 //
 // https://trustedcomputinggroup.org/wp-content/uploads/TCG_PCClient_Specific_Platform_Profile_for_TPM_2p0_1p04_PUBLIC.pdf#page=100
-func ParseUEFIVariableData(r *io.LimitedReader) (ret UEFIVariableData, err error) {
+func ParseUEFIVariableData(data []byte) (ret UEFIVariableData, err error) {
+	r := &io.LimitedReader{R: bytes.NewReader(data), N: int64(len(data))}
 	err = binary.Read(r, binary.LittleEndian, &ret.Header)
 	if err != nil {
 		return
@@ -588,7 +589,8 @@ func (h *EFIImageLoad) DevicePath() ([]EFIDevicePathElement, error) {
 // ParseEFIImageLoad parses an EFI_IMAGE_LOAD_EVENT structure.
 //
 // https://trustedcomputinggroup.org/wp-content/uploads/TCG_EFI_Platform_1_22_Final_-v15.pdf#page=17
-func ParseEFIImageLoad(r *io.LimitedReader) (ret EFIImageLoad, err error) {
+func ParseEFIImageLoad(data []byte) (ret EFIImageLoad, err error) {
+	r := &io.LimitedReader{R: bytes.NewReader(data), N: int64(len(data))}
 	err = binary.Read(r, binary.LittleEndian, &ret.Header)
 	if err != nil {
 		return

--- a/attest/internal/events_test.go
+++ b/attest/internal/events_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+  "io"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -57,7 +58,7 @@ func TestParseUEFIVariableData(t *testing.T) {
 		VariableData: []uint8{0x1},
 	}
 
-	got, err := ParseUEFIVariableData(bytes.NewReader(data))
+	got, err := ParseUEFIVariableData(&io.LimitedReader{R: bytes.NewReader(data), N: int64(len(data))})
 	if err != nil {
 		t.Fatalf("ParseEFIVariableData() failed: %v", err)
 	}

--- a/attest/internal/events_test.go
+++ b/attest/internal/events_test.go
@@ -58,7 +58,7 @@ func TestParseUEFIVariableData(t *testing.T) {
 		VariableData: []uint8{0x1},
 	}
 
-	got, err := ParseUEFIVariableData(&io.LimitedReader{R: bytes.NewReader(data), N: int64(len(data))})
+	got, err := ParseUEFIVariableData(data)
 	if err != nil {
 		t.Fatalf("ParseEFIVariableData() failed: %v", err)
 	}

--- a/attest/internal/events_test.go
+++ b/attest/internal/events_test.go
@@ -2,7 +2,7 @@ package internal
 
 import (
 	"bytes"
-  "io"
+	"io"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"

--- a/attest/internal/events_test.go
+++ b/attest/internal/events_test.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"bytes"
-	"io"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"

--- a/attest/pcp_windows.go
+++ b/attest/pcp_windows.go
@@ -473,7 +473,7 @@ func decodeAKProps20(r *io.LimitedReader) (*akProps, error) {
 
 	// The encoded TPMT_SIGNATURE structure represents the remaining bytes in
 	// the ID binding blob.
-	out.RawSignature = make([]byte, r.Len())
+	out.RawSignature = make([]byte, r.N)
 	if err := binary.Read(r, binary.BigEndian, &out.RawSignature); err != nil {
 		return nil, fmt.Errorf("failed to decode TPMT_SIGNATURE.data: %v", err)
 	}

--- a/attest/pcp_windows.go
+++ b/attest/pcp_windows.go
@@ -363,7 +363,7 @@ func (h *winPCP) AKProperties(kh uintptr) (*akProps, error) {
 	if bytes.Equal(idBlob[0:4], []byte{1, 1, 0, 0}) {
 		return decodeAKProps12(r)
 	}
-	return decodeAKProps20(r)
+	return decodeAKProps20(&io.LimitedReader{R: r, N: int64(r.Len())})
 }
 
 // decodeAKProps12 separates the single TPM 1.2 blob from the PCP property
@@ -389,6 +389,9 @@ func decodeAKProps12(r *bytes.Reader) (*akProps, error) {
 	if err := binary.Read(r, binary.BigEndian, &exponentSize); err != nil {
 		return nil, fmt.Errorf("failed to decode exponentSize: %v", err)
 	}
+	if int64(exponentSize) > int64(r.Len()) {
+		return nil, fmt.Errorf("exponentSize (%d bytes) exceeds remaining capacity (%d bytes)", exponentSize, r.Len())
+	}
 	// Consume the bytes representing the exponent.
 	exp := make([]byte, int(exponentSize))
 	if err := binary.Read(r, binary.BigEndian, &exp); err != nil {
@@ -398,6 +401,9 @@ func decodeAKProps12(r *bytes.Reader) (*akProps, error) {
 	var keyDataSize uint32
 	if err := binary.Read(r, binary.BigEndian, &keyDataSize); err != nil {
 		return nil, fmt.Errorf("failed to decode keyDataSize: %v", err)
+	}
+	if int64(keyDataSize) > int64(r.Len()) {
+		return nil, fmt.Errorf("keyDataSize (%d bytes) exceeds remaining capacity (%d bytes)", keyDataSize, r.Len())
 	}
 	// Seek to the end of the key data.
 	r.Seek(int64(keyDataSize), io.SeekCurrent)
@@ -410,7 +416,11 @@ func decodeAKProps12(r *bytes.Reader) (*akProps, error) {
 
 	// Seek back to the location of the public key, and consume it.
 	r.Seek(int64(pubKeyStartIdx), io.SeekStart)
-	out.RawPublic = make([]byte, 24+int(exponentSize)+4+int(keyDataSize))
+	pubSize := int64(24) + int64(exponentSize) + int64(4) + int64(keyDataSize)
+	if pubSize > int64(r.Len()) {
+		return nil, fmt.Errorf("public structure size (%d bytes) exceeds remaining capacity (%d bytes)", pubSize, r.Len())
+	}
+	out.RawPublic = make([]byte, pubSize)
 	if err := binary.Read(r, binary.BigEndian, &out.RawPublic); err != nil {
 		return nil, fmt.Errorf("failed to decode public: %v", err)
 	}
@@ -422,12 +432,15 @@ func decodeAKProps12(r *bytes.Reader) (*akProps, error) {
 // into its constituents. For TPM 2.0 devices, these are bytes representing
 // the following structures: TPM2B_PUBLIC, TPM2B_CREATION_DATA, TPM2B_ATTEST,
 // and TPMT_SIGNATURE.
-func decodeAKProps20(r *bytes.Reader) (*akProps, error) {
+func decodeAKProps20(r *io.LimitedReader) (*akProps, error) {
 	var out akProps
 
 	var publicSize uint16
 	if err := binary.Read(r, binary.BigEndian, &publicSize); err != nil {
 		return nil, fmt.Errorf("failed to decode TPM2B_PUBLIC.size: %v", err)
+	}
+	if int64(publicSize) > r.N {
+		return nil, fmt.Errorf("TPM2B_PUBLIC.size (%d bytes) larger than remaining capacity (%d bytes)", publicSize, r.N)
 	}
 	out.RawPublic = make([]byte, publicSize)
 	if err := binary.Read(r, binary.BigEndian, &out.RawPublic); err != nil {
@@ -438,6 +451,9 @@ func decodeAKProps20(r *bytes.Reader) (*akProps, error) {
 	if err := binary.Read(r, binary.BigEndian, &creationDataSize); err != nil {
 		return nil, fmt.Errorf("failed to decode TPM2B_CREATION_DATA.size: %v", err)
 	}
+	if int64(creationDataSize) > r.N {
+		return nil, fmt.Errorf("TPM2B_CREATION_DATA.size (%d bytes) larger than remaining capacity (%d bytes)", creationDataSize, r.N)
+	}
 	out.RawCreationData = make([]byte, creationDataSize)
 	if err := binary.Read(r, binary.BigEndian, &out.RawCreationData); err != nil {
 		return nil, fmt.Errorf("failed to decode TPM2B_CREATION_DATA.data: %v", err)
@@ -446,6 +462,9 @@ func decodeAKProps20(r *bytes.Reader) (*akProps, error) {
 	var attestSize uint16
 	if err := binary.Read(r, binary.BigEndian, &attestSize); err != nil {
 		return nil, fmt.Errorf("failed to decode TPM2B_ATTEST.size: %v", err)
+	}
+	if int64(attestSize) > r.N {
+		return nil, fmt.Errorf("TPM2B_ATTEST.size (%d bytes) larger than remaining capacity (%d bytes)", attestSize, r.N)
 	}
 	out.RawAttest = make([]byte, attestSize)
 	if err := binary.Read(r, binary.BigEndian, &out.RawAttest); err != nil {

--- a/attest/secureboot.go
+++ b/attest/secureboot.go
@@ -19,6 +19,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/google/go-attestation/attest/internal"
 )
@@ -146,7 +147,7 @@ func ParseSecurebootState(events []Event) (*SecurebootState, error) {
 				}
 
 			case internal.EFIVariableDriverConfig:
-				v, err := internal.ParseUEFIVariableData(bytes.NewReader(e.Data))
+				v, err := internal.ParseUEFIVariableData(&io.LimitedReader{R: bytes.NewReader(e.Data), N: int64(len(e.Data))})
 				if err != nil {
 					return nil, fmt.Errorf("failed parsing EFI variable at event %d: %v", e.sequence, err)
 				}
@@ -187,7 +188,7 @@ func ParseSecurebootState(events []Event) (*SecurebootState, error) {
 				}
 
 			case internal.EFIVariableAuthority:
-				v, err := internal.ParseUEFIVariableData(bytes.NewReader(e.Data))
+				v, err := internal.ParseUEFIVariableData(&io.LimitedReader{R: bytes.NewReader(e.Data), N: int64(len(e.Data))})
 				if err != nil {
 					return nil, fmt.Errorf("failed parsing UEFI variable data: %v", err)
 				}
@@ -237,7 +238,7 @@ func ParseSecurebootState(events []Event) (*SecurebootState, error) {
 
 			case internal.EFIBootServicesDriver:
 				if !seenSeparator2 {
-					imgLoad, err := internal.ParseEFIImageLoad(bytes.NewReader(e.Data))
+					imgLoad, err := internal.ParseEFIImageLoad(&io.LimitedReader{R: bytes.NewReader(e.Data), N: int64(len(e.Data))})
 					if err != nil {
 						return nil, fmt.Errorf("failed parsing EFI image load at boot services driver event %d: %v", e.sequence, err)
 					}

--- a/attest/secureboot.go
+++ b/attest/secureboot.go
@@ -19,7 +19,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io"
 
 	"github.com/google/go-attestation/attest/internal"
 )
@@ -147,7 +146,7 @@ func ParseSecurebootState(events []Event) (*SecurebootState, error) {
 				}
 
 			case internal.EFIVariableDriverConfig:
-				v, err := internal.ParseUEFIVariableData(&io.LimitedReader{R: bytes.NewReader(e.Data), N: int64(len(e.Data))})
+				v, err := internal.ParseUEFIVariableData(e.Data)
 				if err != nil {
 					return nil, fmt.Errorf("failed parsing EFI variable at event %d: %v", e.sequence, err)
 				}
@@ -188,7 +187,7 @@ func ParseSecurebootState(events []Event) (*SecurebootState, error) {
 				}
 
 			case internal.EFIVariableAuthority:
-				v, err := internal.ParseUEFIVariableData(&io.LimitedReader{R: bytes.NewReader(e.Data), N: int64(len(e.Data))})
+				v, err := internal.ParseUEFIVariableData(e.Data)
 				if err != nil {
 					return nil, fmt.Errorf("failed parsing UEFI variable data: %v", err)
 				}
@@ -238,7 +237,7 @@ func ParseSecurebootState(events []Event) (*SecurebootState, error) {
 
 			case internal.EFIBootServicesDriver:
 				if !seenSeparator2 {
-					imgLoad, err := internal.ParseEFIImageLoad(&io.LimitedReader{R: bytes.NewReader(e.Data), N: int64(len(e.Data))})
+					imgLoad, err := internal.ParseEFIImageLoad(e.Data)
 					if err != nil {
 						return nil, fmt.Errorf("failed parsing EFI image load at boot services driver event %d: %v", e.sequence, err)
 					}

--- a/attest/tpm_windows.go
+++ b/attest/tpm_windows.go
@@ -24,6 +24,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"math/big"
 
 	tpmtbs "github.com/google/go-tpm/tpmutil/tbs"
@@ -170,10 +171,8 @@ type bcryptRSABlobHeader struct {
 
 func decodeWindowsBcryptRSABlob(b []byte) (*rsa.PublicKey, error) {
 	var (
-		r      = bytes.NewReader(b)
+		r      = &io.LimitedReader{R: bytes.NewReader(b), N: int64(len(b))}
 		header = &bcryptRSABlobHeader{}
-		exp    = make([]byte, 8)
-		mod    = []byte("")
 	)
 	if err := binary.Read(r, binary.LittleEndian, header); err != nil {
 		return nil, err
@@ -186,12 +185,22 @@ func decodeWindowsBcryptRSABlob(b []byte) (*rsa.PublicKey, error) {
 		return nil, errors.New("exponent too large")
 	}
 
-	if _, err := r.Read(exp[8-header.ExponentLen:]); err != nil {
+	if int64(header.ExponentLen) > r.N {
+		return nil, fmt.Errorf("ExponentLen (%d bytes) larger than remaining capacity (%d bytes)", header.ExponentLen, r.N)
+	}
+
+	// Allocate an 8-byte buffer to right-align and zero-pad the big-endian exponent
+	// so it can be directly decoded with binary.BigEndian.Uint64 (which requires 8 bytes).
+	exp := make([]byte, 8)
+	if _, err := lr.Read(exp[8-header.ExponentLen:]); err != nil {
 		return nil, fmt.Errorf("failed to read public exponent: %v", err)
 	}
 
-	mod = make([]byte, header.ModulusLen)
-	if n, err := r.Read(mod); n != int(header.ModulusLen) || err != nil {
+	if int64(header.ModulusLen) > lr.N {
+		return nil, fmt.Errorf("ModulusLen (%d bytes) larger than remaining capacity (%d bytes)", header.ModulusLen, lr.N)
+	}
+	mod := make([]byte, header.ModulusLen)
+	if n, err := lr.Read(mod); n != int(header.ModulusLen) || err != nil {
 		return nil, fmt.Errorf("failed to read modulus (%d, %v)", n, err)
 	}
 

--- a/attest/tpm_windows.go
+++ b/attest/tpm_windows.go
@@ -192,15 +192,15 @@ func decodeWindowsBcryptRSABlob(b []byte) (*rsa.PublicKey, error) {
 	// Allocate an 8-byte buffer to right-align and zero-pad the big-endian exponent
 	// so it can be directly decoded with binary.BigEndian.Uint64 (which requires 8 bytes).
 	exp := make([]byte, 8)
-	if _, err := lr.Read(exp[8-header.ExponentLen:]); err != nil {
+	if _, err := r.Read(exp[8-header.ExponentLen:]); err != nil {
 		return nil, fmt.Errorf("failed to read public exponent: %v", err)
 	}
 
-	if int64(header.ModulusLen) > lr.N {
-		return nil, fmt.Errorf("ModulusLen (%d bytes) larger than remaining capacity (%d bytes)", header.ModulusLen, lr.N)
+	if int64(header.ModulusLen) > r.N {
+		return nil, fmt.Errorf("ModulusLen (%d bytes) larger than remaining capacity (%d bytes)", header.ModulusLen, r.N)
 	}
 	mod := make([]byte, header.ModulusLen)
-	if n, err := lr.Read(mod); n != int(header.ModulusLen) || err != nil {
+	if n, err := r.Read(mod); n != int(header.ModulusLen) || err != nil {
 		return nil, fmt.Errorf("failed to read modulus (%d, %v)", n, err)
 	}
 

--- a/attest/win_events.go
+++ b/attest/win_events.go
@@ -340,9 +340,12 @@ type microsoftEventHeader struct {
 // and these structures should match the event digest.
 var errUnknownSIPAEvent = errors.New("unknown event")
 
-func (w *WinEvents) readBooleanInt64Event(header microsoftEventHeader, r *bytes.Reader) error {
+func (w *WinEvents) readBooleanInt64Event(header microsoftEventHeader, r *io.LimitedReader) error {
 	if header.Size != 8 {
 		return fmt.Errorf("payload was %d bytes, want 8", header.Size)
+	}
+	if int64(header.Size) > r.N {
+		return fmt.Errorf("payload size (%d bytes) larger than remaining capacity (%d bytes)", header.Size, r.N)
 	}
 	var num uint64
 	if err := binary.Read(r, binary.LittleEndian, &num); err != nil {
@@ -363,9 +366,12 @@ func (w *WinEvents) readBooleanInt64Event(header microsoftEventHeader, r *bytes.
 	return nil
 }
 
-func (w *WinEvents) readBooleanByteEvent(header microsoftEventHeader, r *bytes.Reader) error {
+func (w *WinEvents) readBooleanByteEvent(header microsoftEventHeader, r *io.LimitedReader) error {
 	if header.Size != 1 {
 		return fmt.Errorf("payload was %d bytes, want 1", header.Size)
+	}
+	if int64(header.Size) > r.N {
+		return fmt.Errorf("payload size (%d bytes) larger than remaining capacity (%d bytes)", header.Size, r.N)
 	}
 	var b byte
 	if err := binary.Read(r, binary.LittleEndian, &b); err != nil {
@@ -395,9 +401,12 @@ func (w *WinEvents) readBooleanByteEvent(header microsoftEventHeader, r *bytes.R
 	return nil
 }
 
-func (w *WinEvents) readUint32(header microsoftEventHeader, r io.Reader) (uint32, error) {
+func (w *WinEvents) readUint32(header microsoftEventHeader, r *io.LimitedReader) (uint32, error) {
 	if header.Size != 4 {
 		return 0, fmt.Errorf("integer size not uint32 (%d bytes)", header.Size)
+	}
+	if int64(header.Size) > r.N {
+		return 0, fmt.Errorf("integer size (%d bytes) larger than remaining capacity (%d bytes)", header.Size, r.N)
 	}
 
 	data := make([]uint8, header.Size)
@@ -409,9 +418,12 @@ func (w *WinEvents) readUint32(header microsoftEventHeader, r io.Reader) (uint32
 	return i, nil
 }
 
-func (w *WinEvents) readUint64(header microsoftEventHeader, r io.Reader) (uint64, error) {
+func (w *WinEvents) readUint64(header microsoftEventHeader, r *io.LimitedReader) (uint64, error) {
 	if header.Size != 8 {
 		return 0, fmt.Errorf("integer size not uint64 (%d bytes)", header.Size)
+	}
+	if int64(header.Size) > r.N {
+		return 0, fmt.Errorf("integer size (%d bytes) larger than remaining capacity (%d bytes)", header.Size, r.N)
 	}
 
 	data := make([]uint8, header.Size)
@@ -423,7 +435,7 @@ func (w *WinEvents) readUint64(header microsoftEventHeader, r io.Reader) (uint64
 	return i, nil
 }
 
-func (w *WinEvents) readBootCounter(header microsoftEventHeader, r *bytes.Reader) error {
+func (w *WinEvents) readBootCounter(header microsoftEventHeader, r *io.LimitedReader) error {
 	i, err := w.readUint64(header, r)
 	if err != nil {
 		return fmt.Errorf("boot counter: %v", err)
@@ -436,7 +448,7 @@ func (w *WinEvents) readBootCounter(header microsoftEventHeader, r *bytes.Reader
 	return nil
 }
 
-func (w *WinEvents) readTransferControl(header microsoftEventHeader, r *bytes.Reader) error {
+func (w *WinEvents) readTransferControl(header microsoftEventHeader, r *io.LimitedReader) error {
 	i, err := w.readUint32(header, r)
 	if err != nil {
 		return fmt.Errorf("transfer control: %v", err)
@@ -449,9 +461,12 @@ func (w *WinEvents) readTransferControl(header microsoftEventHeader, r *bytes.Re
 	return nil
 }
 
-func (w *WinEvents) readBitlockerUnlock(header microsoftEventHeader, r *bytes.Reader, pcr int) error {
+func (w *WinEvents) readBitlockerUnlock(header microsoftEventHeader, r *io.LimitedReader, pcr int) error {
 	if header.Size > 8 {
 		return fmt.Errorf("bitlocker data too large (%d bytes)", header.Size)
+	}
+	if int64(header.Size) > r.N {
+		return fmt.Errorf("bitlocker data size (%d bytes) larger than remaining capacity (%d bytes)", header.Size, r.N)
 	}
 	data := make([]uint8, header.Size)
 	if err := binary.Read(r, binary.LittleEndian, &data); err != nil {
@@ -473,9 +488,12 @@ func (w *WinEvents) readBitlockerUnlock(header microsoftEventHeader, r *bytes.Re
 	return nil
 }
 
-func (w *WinEvents) parseImageValidated(header microsoftEventHeader, r io.Reader) (bool, error) {
+func (w *WinEvents) parseImageValidated(header microsoftEventHeader, r *io.LimitedReader) (bool, error) {
 	if header.Size != 1 {
 		return false, fmt.Errorf("payload was %d bytes, want 1", header.Size)
+	}
+	if int64(header.Size) > r.N {
+		return false, fmt.Errorf("payload size (%d bytes) larger than remaining capacity (%d bytes)", header.Size, r.N)
 	}
 	var num byte
 	if err := binary.Read(r, binary.LittleEndian, &num); err != nil {
@@ -484,7 +502,7 @@ func (w *WinEvents) parseImageValidated(header microsoftEventHeader, r io.Reader
 	return num == 1, nil
 }
 
-func (w *WinEvents) parseHashAlgID(header microsoftEventHeader, r io.Reader) (WinCSPAlg, error) {
+func (w *WinEvents) parseHashAlgID(header microsoftEventHeader, r *io.LimitedReader) (WinCSPAlg, error) {
 	i, err := w.readUint32(header, r)
 	if err != nil {
 		return 0, fmt.Errorf("hash algorithm ID: %v", err)
@@ -498,10 +516,13 @@ func (w *WinEvents) parseHashAlgID(header microsoftEventHeader, r io.Reader) (Wi
 	}
 }
 
-func (w *WinEvents) parseAuthoritySerial(header microsoftEventHeader, r io.Reader) ([]byte, error) {
+func (w *WinEvents) parseAuthoritySerial(header microsoftEventHeader, r *io.LimitedReader) ([]byte, error) {
 	if header.Size > 128 {
 		return nil, fmt.Errorf("authority serial is too long (%d bytes)", header.Size)
 	}
+	if int64(header.Size) > r.N {
+		return nil, fmt.Errorf("authority serial size (%d bytes) larger than remaining capacity (%d bytes)", header.Size, r.N)
+	}
 	data := make([]byte, header.Size)
 	if err := binary.Read(r, binary.LittleEndian, &data); err != nil {
 		return nil, fmt.Errorf("reading bytes: %w", err)
@@ -509,10 +530,13 @@ func (w *WinEvents) parseAuthoritySerial(header microsoftEventHeader, r io.Reade
 	return data, nil
 }
 
-func (w *WinEvents) parseAuthoritySHA1(header microsoftEventHeader, r io.Reader) ([]byte, error) {
+func (w *WinEvents) parseAuthoritySHA1(header microsoftEventHeader, r *io.LimitedReader) ([]byte, error) {
 	if header.Size > 20 {
 		return nil, fmt.Errorf("authority thumbprint is too long (%d bytes)", header.Size)
 	}
+	if int64(header.Size) > r.N {
+		return nil, fmt.Errorf("authority thumbprint size (%d bytes) larger than remaining capacity (%d bytes)", header.Size, r.N)
+	}
 	data := make([]byte, header.Size)
 	if err := binary.Read(r, binary.LittleEndian, &data); err != nil {
 		return nil, fmt.Errorf("reading bytes: %w", err)
@@ -520,9 +544,12 @@ func (w *WinEvents) parseAuthoritySHA1(header microsoftEventHeader, r io.Reader)
 	return data, nil
 }
 
-func (w *WinEvents) parseImageBase(header microsoftEventHeader, r io.Reader) (uint64, error) {
+func (w *WinEvents) parseImageBase(header microsoftEventHeader, r *io.LimitedReader) (uint64, error) {
 	if header.Size != 8 {
 		return 0, fmt.Errorf("payload was %d bytes, want 8", header.Size)
+	}
+	if int64(header.Size) > r.N {
+		return 0, fmt.Errorf("payload size (%d bytes) larger than remaining capacity (%d bytes)", header.Size, r.N)
 	}
 	var num uint64
 	if err := binary.Read(r, binary.LittleEndian, &num); err != nil {
@@ -531,9 +558,12 @@ func (w *WinEvents) parseImageBase(header microsoftEventHeader, r io.Reader) (ui
 	return num, nil
 }
 
-func (w *WinEvents) parseAuthenticodeHash(header microsoftEventHeader, r io.Reader) ([]byte, error) {
+func (w *WinEvents) parseAuthenticodeHash(header microsoftEventHeader, r *io.LimitedReader) ([]byte, error) {
 	if header.Size > 32 {
 		return nil, fmt.Errorf("authenticode hash data exceeds the size of any valid hash (%d bytes)", header.Size)
+	}
+	if int64(header.Size) > r.N {
+		return nil, fmt.Errorf("authenticode hash size (%d bytes) larger than remaining capacity (%d bytes)", header.Size, r.N)
 	}
 	data := make([]byte, header.Size)
 	if err := binary.Read(r, binary.LittleEndian, &data); err != nil {
@@ -542,9 +572,9 @@ func (w *WinEvents) parseAuthenticodeHash(header microsoftEventHeader, r io.Read
 	return data, nil
 }
 
-func (w *WinEvents) readLoadedModuleAggregation(rdr *bytes.Reader, header microsoftEventHeader) error {
-	if available := int64(rdr.Len()); int64(header.Size) > available {
-		return fmt.Errorf("LMA event data (%d bytes) larger than available data (%d bytes)", header.Size, available)
+func (w *WinEvents) readLoadedModuleAggregation(rdr *io.LimitedReader, header microsoftEventHeader) error {
+	if int64(header.Size) > rdr.N {
+		return fmt.Errorf("LMA event data (%d bytes) larger than remaining capacity (%d bytes)", header.Size, rdr.N)
 	}
 
 	var (
@@ -641,6 +671,9 @@ func (w *WinEvents) readLoadedModuleAggregation(rdr *bytes.Reader, header micros
 			}
 		case moduleSVN:
 			// Ignore - consume value.
+			if int64(h.Size) > r.N {
+				return fmt.Errorf("moduleSVN size (%d bytes) larger than remaining capacity (%d bytes)", h.Size, r.N)
+			}
 			b := make([]byte, h.Size)
 			if err := binary.Read(r, binary.LittleEndian, &b); err != nil {
 				return err
@@ -683,11 +716,9 @@ func (w *WinEvents) parseUTF16(header microsoftEventHeader, r io.Reader) (string
 	return strings.TrimSuffix(string(utf16.Decode(data)), "\x00"), nil
 }
 
-func (w *WinEvents) readELAMAggregation(rdr io.Reader, header microsoftEventHeader) error {
-	if br, ok := rdr.(*bytes.Reader); ok {
-		if available := int64(br.Len()); int64(header.Size) > available {
-			return fmt.Errorf("ELAM aggregation event data (%d bytes) larger than available data (%d bytes)", header.Size, available)
-		}
+func (w *WinEvents) readELAMAggregation(rdr *io.LimitedReader, header microsoftEventHeader) error {
+	if int64(header.Size) > rdr.N {
+		return fmt.Errorf("ELAM aggregation event data (%d bytes) larger than remaining capacity (%d bytes)", header.Size, rdr.N)
 	}
 
 	var (
@@ -763,7 +794,7 @@ func (w *WinEvents) readELAMAggregation(rdr io.Reader, header microsoftEventHead
 	return nil
 }
 
-func (w *WinEvents) readSIPAEvent(r *bytes.Reader, pcr int) error {
+func (w *WinEvents) readSIPAEvent(r *io.LimitedReader, pcr int) error {
 	var header microsoftEventHeader
 	if err := binary.Read(r, binary.LittleEndian, &header); err != nil {
 		return err
@@ -788,8 +819,8 @@ func (w *WinEvents) readSIPAEvent(r *bytes.Reader, pcr int) error {
 
 	default:
 		// Event type was not handled, consume the data.
-		if int(header.Size) > r.Len() {
-			return fmt.Errorf("event data len (%d bytes) larger than event length (%d bytes)", header.Size, r.Len())
+		if int64(header.Size) > r.N {
+			return fmt.Errorf("event data len (%d bytes) larger than remaining capacity (%d bytes)", header.Size, r.N)
 		}
 		tmp := make([]byte, header.Size)
 		if err := binary.Read(r, binary.LittleEndian, &tmp); err != nil {
@@ -803,7 +834,7 @@ func (w *WinEvents) readSIPAEvent(r *bytes.Reader, pcr int) error {
 // readWinEventBlock extracts boot configuration from SIPA events contained in
 // the given tagged event.
 func (w *WinEvents) readWinEventBlock(evt *internal.TaggedEventData, pcr int) error {
-	r := bytes.NewReader(evt.Data)
+	lr := &io.LimitedReader{R: bytes.NewReader(evt.Data), N: int64(len(evt.Data))}
 
 	// All windows information should be sub events in an enclosing SIPA
 	// container event.
@@ -811,8 +842,8 @@ func (w *WinEvents) readWinEventBlock(evt *internal.TaggedEventData, pcr int) er
 		return fmt.Errorf("expected container event, got %v", windowsEvent(evt.ID))
 	}
 
-	for r.Len() > 0 {
-		if err := w.readSIPAEvent(r, pcr); err != nil {
+	for lr.N > 0 {
+		if err := w.readSIPAEvent(lr, pcr); err != nil {
 			if errors.Is(err, errUnknownSIPAEvent) {
 				// Unknown SIPA events are okay as all TCG events are verifiable.
 				continue


### PR DESCRIPTION
Refactor binary input parsing in attestation library to bound make() allocations by remaining reader capacity using io.LimitedReader.

Previously, user-controlled size fields read via binary.Read were used directly in make() calls without capping against remaining input bytes. A malformed or crafted payload with inflated size headers could trigger multi-gigabyte memory allocations before encountering EOF, enabling denial-of-service via out-of-memory crashes.

Key changes:

* Wrap top-level and nested binary streams in io.LimitedReader across secureboot.go, win_events.go, pcp_windows.go, and tpm_windows.go.
* Add fail-fast check guards (requestedSize > reader.N) before slice allocations so truncated or invalid payloads fail immediately without allocating.
* Protect container aggregations, UEFI variables, and Windows PCP/TPM decoders against allocation amplification.
* Update ParseUEFIVariableData and ParseEFIImageLoad signatures in internal/events.go from io.Reader to *io.LimitedReader.
* Enforce direct remaining capacity guards (requestedSize > lr.N) before make() allocations in ParseUEFIVariableData, ParseEFIImageLoad, and parseDevicePathElement.
* Update callers in secureboot.go and internal/events_test.go to wrap binary input slices in io.LimitedReader.